### PR TITLE
Fix context menu when scrolling

### DIFF
--- a/moonlight-web/web-server/web/component/context_menu.ts
+++ b/moonlight-web/web-server/web/component/context_menu.ts
@@ -28,8 +28,8 @@ export function setContextMenu(event: MouseEvent, init?: ContextMenuInit) {
         return;
     }
 
-    contextMenuElement.style.setProperty("left", `${event.pageX}px`)
-    contextMenuElement.style.setProperty("top", `${event.pageY}px`)
+    contextMenuElement.style.setProperty("left", `${event.clientX}px`)
+    contextMenuElement.style.setProperty("top", `${event.clientY}px`)
 
     contextMenuList.clear()
 


### PR DESCRIPTION
This fixes a bug, where the context menu would appear in the wrong location if you scroll down on the hosts or games page. If you scrolled down far enough, the context menu would disappear off screen, completely preventing you from starting games at the bottom of long lists.