### PR TITLE
Fix connection closing after a few seconds of stream on chrome

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ roxmltree = { version = "0.20.0" }
 form_urlencoded = { version = "1.2.1" }
 
 # WebRTC
-webrtc = "0.14.0"
+webrtc = "0.17.1"
 
 # Actix
 actix-web = { version = "4.11.0" }


### PR DESCRIPTION
Closes #79 

The new chrome update changed a flag that would replace the use of local ips with mDNS hostnames in ice candidates. Updating the webrtc library fixes this problem. I have no idea why. There is maybe a better way of doing this.