### PR TITLE
Remove printf-compat dependency for stable Rust compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ moonlight-common-sys = { path = "./moonlight-common-sys" }
 # Log
 log = "0.4.28"
 simplelog = "0.12.2"
-printf-compat = { version = "0.3.0" }
 
 # Cli
 clap = { version = "4.5.53" }

--- a/moonlight-common/Cargo.toml
+++ b/moonlight-common/Cargo.toml
@@ -16,7 +16,6 @@ thiserror = { workspace = true }
 
 # Stream
 moonlight-common-sys = { workspace = true, optional = true }
-printf-compat = { workspace = true, optional = true }
 
 # Network
 uuid = { workspace = true, features = ["v4"], optional = true }
@@ -57,7 +56,7 @@ default = ["high", "stream", "backend_reqwest"]
 high = ["network", "pair", "dep:log", "dep:tokio"]
 
 # Moonlight Common C / Stream
-stream = ["dep:moonlight-common-sys", "dep:log", "dep:printf-compat"]
+stream = ["dep:moonlight-common-sys", "dep:log"]
 
 # Pairing
 pair = ["network"]

--- a/moonlight-common/src/lib.rs
+++ b/moonlight-common/src/lib.rs
@@ -1,6 +1,3 @@
-// Sadly moonlight log message requires variadic args
-#![feature(c_variadic)]
-
 use std::{
     ffi::NulError,
     fmt::{Debug, Display},


### PR DESCRIPTION
printf-compat requires nightly (c_variadic feature). Replace the log_message callback with None until c_variadic is stabilized. The ConnectionListener::log_message trait method is preserved for forward compatibility.