### PR TITLE
Claude/check pbkdf2 iterations 2pq xj

### DIFF
--- a/src/app/password.rs
+++ b/src/app/password.rs
@@ -2,7 +2,7 @@ use openssl::{hash::MessageDigest, pkcs5, rand::rand_bytes};
 
 use crate::app::AppError;
 
-const HASH_ITERATIONS: usize = 150_000;
+const HASH_ITERATIONS: usize = 600_000;
 
 #[derive(Clone)]
 pub struct StoragePassword {

--- a/src/app/password.rs
+++ b/src/app/password.rs
@@ -2,16 +2,22 @@ use openssl::{hash::MessageDigest, pkcs5, rand::rand_bytes};
 
 use crate::app::AppError;
 
-const HASH_ITERATIONS: usize = 600_000;
+pub const HASH_ITERATIONS: u32 = 600_000;
 
 #[derive(Clone)]
 pub struct StoragePassword {
     pub salt: [u8; 16],
     pub hash: [u8; 32],
+    pub iterations: u32,
 }
 
 impl StoragePassword {
-    fn hash(salt: &[u8; 16], password: &str, out: &mut [u8; 32]) -> Result<(), AppError> {
+    fn hash(
+        salt: &[u8; 16],
+        iterations: u32,
+        password: &str,
+        out: &mut [u8; 32],
+    ) -> Result<(), AppError> {
         if password.is_empty() {
             return Err(AppError::PasswordEmpty);
         }
@@ -19,7 +25,7 @@ impl StoragePassword {
         pkcs5::pbkdf2_hmac(
             password.as_bytes(),
             salt,
-            HASH_ITERATIONS,
+            iterations as usize,
             MessageDigest::sha256(),
             out,
         )?;
@@ -34,15 +40,23 @@ impl StoragePassword {
 
         let mut hash = [0u8; 32];
 
-        Self::hash(&salt, password, &mut hash)?;
+        Self::hash(&salt, HASH_ITERATIONS, password, &mut hash)?;
 
-        Ok(Self { salt, hash })
+        Ok(Self {
+            salt,
+            hash,
+            iterations: HASH_ITERATIONS,
+        })
     }
 
     pub fn verify(&self, password: &str) -> Result<bool, AppError> {
         let mut hash = [0u8; 32];
-        Self::hash(&self.salt, password, &mut hash)?;
+        Self::hash(&self.salt, self.iterations, password, &mut hash)?;
 
         Ok(self.hash == hash)
+    }
+
+    pub fn needs_rehash(&self) -> bool {
+        self.iterations < HASH_ITERATIONS
     }
 }

--- a/src/app/storage/json/mod.rs
+++ b/src/app/storage/json/mod.rs
@@ -292,6 +292,7 @@ fn user_from_json(user_id: UserId, user: &V3User) -> StorageUser {
         password: user.password.as_ref().map(|password| StoragePassword {
             salt: password.salt,
             hash: password.hash,
+            iterations: password.iterations,
         }),
         role_id: RoleId(user.role_id),
         client_unique_id: user.client_unique_id.clone(),
@@ -484,6 +485,7 @@ impl Storage for JsonStorage {
             password: user.password.map(|password| V2UserPassword {
                 salt: password.salt,
                 hash: password.hash,
+                iterations: password.iterations,
             }),
             client_unique_id: user.client_unique_id,
         };
@@ -520,6 +522,7 @@ impl Storage for JsonStorage {
             password: user.password.map(|password| StoragePassword {
                 salt: password.salt,
                 hash: password.hash,
+                iterations: password.iterations,
             }),
             role_id: RoleId(user.role_id),
             client_unique_id: user.client_unique_id,
@@ -539,6 +542,7 @@ impl Storage for JsonStorage {
             user.password = password.map(|password| V2UserPassword {
                 salt: password.salt,
                 hash: password.hash,
+                iterations: password.iterations,
             });
         }
         if let Some(role_id) = modify.role_id {

--- a/src/app/storage/json/versions.rs
+++ b/src/app/storage/json/versions.rs
@@ -116,6 +116,15 @@ pub struct V2UserPassword {
     pub salt: [u8; 16],
     #[serde(with = "hex_array")]
     pub hash: [u8; 32],
+    // Older storage files predate per-hash iteration tracking; default to the
+    // value that was used at the time those hashes were created so they keep
+    // verifying after the global iteration count is increased.
+    #[serde(default = "default_legacy_iterations")]
+    pub iterations: u32,
+}
+
+fn default_legacy_iterations() -> u32 {
+    150_000
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/user.rs
+++ b/src/app/user.rs
@@ -175,7 +175,13 @@ impl User {
                 if let Some(storage_password) = storage.password.as_ref()
                     && storage_password.verify(password)?
                 {
-                    Ok(AuthenticatedUser { inner: self })
+                    let needs_rehash = storage_password.needs_rehash();
+                    let mut authenticated = AuthenticatedUser { inner: self };
+                    if needs_rehash {
+                        let rehashed = StoragePassword::new(password)?;
+                        authenticated.set_password(rehashed).await?;
+                    }
+                    Ok(authenticated)
                 } else {
                     Err(AppError::CredentialsWrong)
                 }


### PR DESCRIPTION
Increase iterations from 150,000 to 600,000 to align with the current
OWASP Password Storage Cheat Sheet recommendation for PBKDF2-HMAC-SHA256.

________________________________________________________________________________________________________
# AI generated summary:

**Title**

```
Bump PBKDF2-HMAC-SHA256 iterations to OWASP recommendation (600k) with backward-compatible migration
```

**Description**

````markdown
## Summary

Raises the PBKDF2-HMAC-SHA256 iteration count in `StoragePassword` from **150,000** to **600,000** to match the current [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2) recommendation.

To avoid invalidating existing accounts, the iteration count is now stored **per hash**, and legacy hashes are transparently rehashed to the new default on the next successful login.

## Motivation

`HASH_ITERATIONS` was set to `150_000`, well below the current OWASP recommendation of `600_000` for PBKDF2-HMAC-SHA256. That makes brute-forcing stolen hashes cheaper than it should be.

Simply bumping the constant would have invalidated every existing password hash (no more logins for accounts created with 150k iterations), because the iteration count was not stored alongside the hash.

## Changes

- **`src/app/password.rs`**
  - New field `StoragePassword::iterations: u32`.
  - `verify` uses `self.iterations` instead of the global constant, so legacy hashes still verify.
  - `new` sets the field to the current default (`HASH_ITERATIONS = 600_000`).
  - New `needs_rehash()` helper for the migration heuristic.
- **`src/app/storage/json/versions.rs`**
  - `V2UserPassword` gains an `iterations: u32` field with `#[serde(default = "default_legacy_iterations")]` → `150_000`. Existing JSON storage files keep deserializing correctly without a version bump.
- **`src/app/storage/json/mod.rs`**
  - The four conversion sites pass the `iterations` field through between `StoragePassword` and `V2UserPassword`.
- **`src/app/user.rs`**
  - In `User::authenticate`, after a successful verify with a legacy iteration count, a fresh hash is generated with the current default and persisted via `set_password` (lazy rehash).

## Backward Compatibility

- Existing storage JSON files (without the `iterations` field) are read correctly → defaults to `150_000`.
- Existing passwords verify unchanged.
- The first successful login per account transparently upgrades the stored hash to 600k.
- No schema migration, no password resets, no downtime.

## Performance

For accounts still on legacy hashes, an additional PBKDF2 computation at 600k iterations runs exactly once (the first login after the upgrade). On modern hardware that is in the range of a few hundred milliseconds — comparable to a regular verification and acceptable for a login flow.

## Test Plan

- [x] `cargo check` succeeds
- [ ] `cargo test`
- [ ] Manual: create a new user, log in/out → stored hash has `iterations = 600_000`.
- [ ] Manual: load an existing storage file with a legacy hash → login works → after login the file shows `iterations = 600_000`.
- [ ] Manual: a wrong password is still rejected correctly.

## Notes

- `iterations` is modeled as `u32`, which is more than sufficient for PBKDF2 iteration counts.
- If a future move to Argon2id is on the roadmap, the next step would be a fully versioned hash format (e.g. `v2$argon2id$...`). This PR intentionally stays minimal and does not pre-build that abstraction.
````