### PR TITLE
ci: add manual workflow to automate version bumping and tagging

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0 # Fetch all history so we can push back to branches
 
       - name: Update version and Tag

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,43 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (e.g., 2.9.0)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'main'
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # Fetch all history so we can push back to branches
+
+      - name: Update version and Tag
+        run: |
+          VERSION=${{ github.event.inputs.version }}
+          
+          # 1. Update version in Cargo.toml
+          sed -i "0,/^version = .*/s//version = \"$VERSION\"/" Cargo.toml
+          
+          # 2. Commit and Push changes
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml
+          git commit -m "chore: bump version to $VERSION"
+          git push origin ${{ github.event.inputs.branch }}
+          
+          # 3. Create Tag and Push (Triggers the subsequent Release workflow)
+          git tag v$VERSION
+          git push origin v$VERSION

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,7 +10,7 @@ on:
       branch:
         description: 'Branch to release from'
         required: true
-        default: 'main'
+        default: 'master'
         type: string
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,18 +26,23 @@ jobs:
 
       - name: Update version and Tag
         run: |
-          VERSION=${{ github.event.inputs.version }}
+          # 1. Get raw input
+          RAW_VERSION=${{ github.event.inputs.version }}
           
-          # 1. Update version in Cargo.toml
+          # 2. Normalize: Remove 'v' prefix if user accidentally included it to get the pure version number (e.g., v1.2.3 -> 1.2.3)
+          VERSION=${RAW_VERSION#v}
+          
+          # 3. Update version in Cargo.toml
           sed -i "0,/^version = .*/s//version = \"$VERSION\"/" Cargo.toml
           
-          # 2. Commit and Push changes
+          # 4. Commit and Push changes
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml
           git commit -m "chore: bump version to $VERSION"
           git push origin ${{ github.event.inputs.branch }}
           
-          # 3. Create Tag and Push (Triggers the subsequent Release workflow)
-          git tag v$VERSION
-          git push origin v$VERSION
+          # 5. Create Tag (Ensure it starts with 'v') and Push
+          NEW_TAG="v$VERSION"
+          git tag $NEW_TAG
+          git push origin $NEW_TAG

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ web/api_bindings.ts
 
 # Server
 server
+
+/.idea


### PR DESCRIPTION
### Summary

This PR introduces a new manual GitHub Actions workflow (Prepare Release) to streamline the release process. It ensures that the version number in Cargo.toml is always perfectly synchronized with the GitHub Release Tag.
### Why this is needed

Currently, manually updating the version and pushing tags can lead to a "version mismatch" where the CLI output (CARGO_PKG_VERSION) does not match the GitHub Release tag. This workflow automates that process to eliminate human error.


### Key Features
- Manual Trigger: Allows users to input the target version number via the GitHub UI.
- Auto-Normalization: Automatically handles version inputs with or without the v prefix (e.g., both 1.2.3 and v1.2.3 work).
-  Atomic Updates: Updates Cargo.toml, commits the change, and creates the Git tag in a single automated flow.
- Seamless Integration: Once the tag is pushed by this workflow, it automatically triggers the existing release/docker pipelines.
-  Infrastructure Update: Upgraded actions/checkout to v5 to ensure compatibility with Node.js 24 and avoid future deprecation issues.

### How to use

1. Go to the Actions tab in GitHub.
2. Select Prepare Release (Manual).
3. Click Run workflow, enter the new version (e.g., 1.2.3), and select the target branch.
4. The workflow will handle the rest and trigger the final release.

    

### Final Note

Tip: This approach establishes a "Single Source of Truth" for our releases. By centralizing the versioning and tagging logic within GitHub Actions, we ensure perfect consistency between the code and the release artifacts. It is significantly safer and more robust than manual tagging from a local machine.