### PR TITLE
fix AV1 frames aren't sent, fix codecs mapping on Firefox

### DIFF
--- a/streamer/src/transport/webrtc/video.rs
+++ b/streamer/src/transport/webrtc/video.rs
@@ -43,7 +43,6 @@ use crate::transport::{
         WebRtcInner,
         sender::{SequencedTrackLocalStaticRTP, TrackLocalSender},
         video::{
-            annexb::AnnexBSplitter,
             h264::{payloader::H264Payloader, reader::H264Reader},
             h265::{payloader::H265Payloader, reader::H265Reader},
         },
@@ -67,7 +66,6 @@ enum VideoCodec {
         payloader: H265Payloader,
     },
     Av1 {
-        annex_b: AnnexBSplitter<Cursor<Vec<u8>>>,
         payloader: Av1Payloader,
     },
 }
@@ -209,7 +207,6 @@ impl WebRtcVideo {
             | VideoFormat::Av1Main10
             | VideoFormat::Av1High8_444
             | VideoFormat::Av1High10_444 => Some(VideoCodec::Av1 {
-                annex_b: AnnexBSplitter::new(Cursor::new(Vec::new()), 0),
                 payloader: Default::default(),
             }),
         };
@@ -310,15 +307,8 @@ impl WebRtcVideo {
                 .await;
             }
             // -- AV1
-            Some(VideoCodec::Av1 { annex_b, payloader }) => {
-                annex_b.reset(Cursor::new(full_frame));
-
-                while let Ok(Some(annex_b_payload)) = annex_b.next() {
-                    let data =
-                        trim_bytes_to_range(annex_b_payload.full, annex_b_payload.payload_range);
-
-                    self.samples.push(data);
-                }
+            Some(VideoCodec::Av1 { payloader }) => {
+                self.samples.push(BytesMut::from(full_frame.as_slice()));
 
                 send_single_frame(
                     &mut self.samples,

--- a/web/stream/index.ts
+++ b/web/stream/index.ts
@@ -66,15 +66,24 @@ function getVideoCodecHint(settings: Settings): VideoCodecSupport {
         videoCodecHint.H265_REXT8_444 = true
         videoCodecHint.H265_REXT10_444 = true
     } else if (settings.videoCodec == "av1") {
-        videoCodecHint.AV1 = true
         videoCodecHint.AV1_MAIN8 = true
         videoCodecHint.AV1_MAIN10 = true
-        videoCodecHint.AV1_REXT8_444 = true
-        videoCodecHint.AV1_REXT10_444 = true
+        videoCodecHint.AV1_HIGH8_444 = true
+        videoCodecHint.AV1_HIGH10_444 = true
     } else if (settings.videoCodec == "auto") {
         videoCodecHint = allVideoCodecs()
     }
+
+    if (isFirefox()) {
+        videoCodecHint.AV1_MAIN10 = false
+        videoCodecHint.AV1_HIGH10_444 = false
+    }
+
     return videoCodecHint
+}
+
+function isFirefox(): boolean {
+    return navigator.userAgent.includes("Firefox/")
 }
 
 const WEBRTC_CONNECT_TIMEOUT_MS = 15000

--- a/web/stream/video.ts
+++ b/web/stream/video.ts
@@ -28,8 +28,8 @@ export const CAPABILITIES_CODECS: Record<keyof VideoCodecSupport, { mimeType: st
     // Av1
     "AV1_MAIN8": { mimeType: "video/AV1", fmtpLine: [] }, // <-- Safari AV1 fmtpLine is empty
     "AV1_MAIN10": { mimeType: "video/AV1", fmtpLine: [] }, // <-- Safari AV1 fmtpLine is empty
-    "AV1_HIGH8": { mimeType: "video/AV1", fmtpLine: ["profile=1"] },
-    "AV1_HIGH10": { mimeType: "video/AV1", fmtpLine: ["profile=1"] },
+    "AV1_HIGH8_444": { mimeType: "video/AV1", fmtpLine: ["profile=1"] },
+    "AV1_HIGH10_444": { mimeType: "video/AV1", fmtpLine: ["profile=1"] },
 }
 
 export function emptyVideoCodecs(): VideoCodecSupport {


### PR DESCRIPTION
- Send AV1 frames directly through Av1Payloader instead of splitting them with H264/H265 Annex-B start-code logic.
- Fix AV1 4:4:4 codec hint keys to use AV1_HIGH8_444 / AV1_HIGH10_444.
- Keep AV1 Main10 available on Chrome, but disable AV1 10-bit variants on Firefox to avoid receiving RTP successfully
    while dropping all decoded frames.