### PR TITLE
fix navigator.keyboard.lock in iframe environments

### DIFF
--- a/web/stream.ts
+++ b/web/stream.ts
@@ -58,7 +58,10 @@ async function startApp() {
     const app = new ViewerApp(api, hostId, appId, bootstrapRole.role)
     app.mount(rootElement);
 
-    (window as any)["app"] = app
+    (window as any)["app"] = app;
+    (window as any).postMessage({
+        type: "app:ready"
+    }, "*");
 }
 
 // Prevent starting transition
@@ -89,7 +92,17 @@ class ViewerApp implements Component {
     private pendingAutoFullscreenPrompt: boolean = false
     private fullscreenPromptShown: boolean = false
     private toggleFullscreenWithKeybind: boolean = false
-    private hasShownFullscreenEscapeWarning = false
+
+    private fullscreenEscapeWarningStrategy: () => boolean = (() => {
+        let hasShownFullscreenEscapeWarning = false;
+        return () => {
+            if (!hasShownFullscreenEscapeWarning) {
+                hasShownFullscreenEscapeWarning = true;
+                return true;
+            }
+            return false;
+        };
+    })();
 
     constructor(api: Api, hostId: number, appId: number, bootstrapRole: DetailedRole) {
         this.api = api
@@ -432,14 +445,8 @@ class ViewerApp implements Component {
                     console.warn("failed to request fullscreen", e)
                 }
             }
-
-            if ("keyboard" in navigator && navigator.keyboard && "lock" in navigator.keyboard) {
-                await navigator.keyboard.lock()
-
-                if (!this.hasShownFullscreenEscapeWarning) {
-                    await showMessage(I.stream.fullscreenEscapeHint)
-                }
-                this.hasShownFullscreenEscapeWarning = true
+            if (this.requestKeyboardLock) {
+                await this.requestKeyboardLock();
             }
 
             if (this.getStream()?.getInput().getConfig().mouseMode == "relative") {
@@ -469,6 +476,56 @@ class ViewerApp implements Component {
         if ("exitFullscreen" in document && typeof document.exitFullscreen == "function") {
             await document.exitFullscreen()
         }
+    }
+    requestKeyboardLock(keys?: string[]): Promise<void> {
+        type RequestKeyboardLockFunc = (keys?: string[]) => Promise<void>;
+
+        let requestKeyboardLockFunc: RequestKeyboardLockFunc | undefined;
+        let topWindow = window.top;
+
+        if (window.self === topWindow) {
+            if ("keyboard" in navigator && navigator.keyboard && "lock" in navigator.keyboard) {
+                requestKeyboardLockFunc = navigator.keyboard.lock.bind(navigator.keyboard);
+            }
+        } else if (topWindow) {
+            let sameOrigin = false;
+            try {
+                sameOrigin = window.location.origin === topWindow.location.origin;
+            } catch (e) {}
+
+            if (sameOrigin) {
+                if ("keyboard" in topWindow.navigator && topWindow.navigator.keyboard && "lock" in topWindow.navigator.keyboard) {
+                    requestKeyboardLockFunc = topWindow.navigator.keyboard.lock.bind(topWindow.navigator.keyboard);
+                }
+            } else {
+                requestKeyboardLockFunc = (keys?: string[]) => {
+                    const requestId = Math.random().toString(36).substring(2, 9);
+                    window.parent.postMessage({
+                        type: "REQUEST_KEYBOARD_LOCK",
+                        requestId,
+                        keys
+                    }, "*");
+                    return Promise.resolve();
+                };
+            }
+        }
+
+        if (!requestKeyboardLockFunc) {
+            this.requestKeyboardLock = () => Promise.resolve();
+            return Promise.resolve();
+        }
+        let requestKeyboardLockAndWarn = (k?: string[]) => {
+            return requestKeyboardLockFunc!(k).then(() => {
+                if (this.fullscreenEscapeWarningStrategy?.()) {
+                    return showMessage(I.stream.fullscreenEscapeHint);
+                }
+            });
+        } ;
+        this.requestKeyboardLock = requestKeyboardLockAndWarn;
+        return requestKeyboardLockAndWarn(keys);
+    }
+    setFullscreenEscapeWarningStrategy(strategy: () => boolean) {
+        this.fullscreenEscapeWarningStrategy = strategy;
     }
     isFullscreen(): boolean {
         return "fullscreenElement" in document && !!document.fullscreenElement


### PR DESCRIPTION
### Description

This PR addresses the issue where `navigator.keyboard.lock` fails to function correctly when the application is hosted within an iframe, especially in scenarios involving multiple nested iframes.

### Key Changes
- **Iframe Adaptation**: The logic now detects the nesting context and attempts to access the keyboard lock API from the appropriate scope.
- **Same-Origin Support**: For same-origin iframes, the implementation binds to `window.top.navigator` to ensure the API call preserves the correct execution context and avoids "Illegal invocation" errors.
- **Experimental Cross-Origin Support**:
  - Added a basic `postMessage` bridge to request keyboard locks via the parent window.
  - **Note**: This is a foundational implementation for cross-domain environments. It remains unverified and should be treated as experimental.

### Important Notes
- **Protocol**: The cross-origin bridge assumes the parent window implements a listener for `REQUEST_KEYBOARD_LOCK`.
- **Persistence**: Once a valid locking method is identified (either native or the postMessage bridge), it is cached to the instance to streamline subsequent calls.