### PR TITLE
add default config automatic log file generation

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -62,7 +62,7 @@ impl Default for LogConfig {
     fn default() -> Self {
         Self {
             level_filter: default_level_filter(),
-            file_path: None,
+            file_path: default_log_file_path(),
             dev_venator: default_dev_venator(),
         }
     }
@@ -70,6 +70,10 @@ impl Default for LogConfig {
 
 fn default_level_filter() -> LevelFilter {
     LevelFilter::Info
+}
+
+fn default_log_file_path() -> Option<String> {
+    Some("./server/log.txt".to_string())
 }
 
 fn default_dev_venator() -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,8 +141,9 @@ fn init_log(config: &Config) -> Option<non_blocking::WorkerGuard> {
     let (file_layer, guard) = if let Some(log_file) = &config.log.file_path {
         let file = OpenOptions::new()
             .create(true)
-            .write(true)
-            .truncate(true)
+            .append(true)
+            // .write(true)
+            // .truncate(true)
             .open(log_file)
             .expect("failed to open log file");
 


### PR DESCRIPTION
Should address the [automatic log file generation bug](https://github.com/MrCreativ3001/moonlight-web-stream/issues/107#issuecomment-4230276944) mentioned in #107 by removing the need for manual editing of config.json

* Adds a default log file path to the default config that gets generated initially
* Changes default log file write mode to append mode