### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,4 +33,4 @@ RUN chown moonlight:moonlight ${MOONLIGHT_WEB_PATH}/entrypoint.sh && \
 USER moonlight
 
 # Run the binary
-ENTRYPOINT ["${MOONLIGHT_WEB_PATH}/entrypoint.sh"]
+ENTRYPOINT ["$MOONLIGHT_WEB_PATH/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,12 +25,12 @@ ENV WEBRTC_PORT_RANGE=40000:40100
 EXPOSE 8080 40000-40100/udp
 
 # Create an entrypoint
-COPY entrypoint.sh ${MOONLIGHT_WEB_PATH}/entrypoint.sh
-RUN chown moonlight:moonlight ${MOONLIGHT_WEB_PATH}/entrypoint.sh && \
-    chmod +x ${MOONLIGHT_WEB_PATH}/entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chown moonlight:moonlight /entrypoint.sh && \
+    chmod +x /entrypoint.sh
 
 # Switch to the non-root user
 USER moonlight
 
 # Run the binary
-ENTRYPOINT ["$MOONLIGHT_WEB_PATH/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ EXPOSE 8080 40000-40100/udp
 # Create an entrypoint
 COPY entrypoint.sh ${MOONLIGHT_WEB_PATH}/entrypoint.sh
 RUN chown moonlight:moonlight ${MOONLIGHT_WEB_PATH}/entrypoint.sh && \
-    chmod +x /entrypoint.sh
+    chmod +x ${MOONLIGHT_WEB_PATH}/entrypoint.sh
 
 # Switch to the non-root user
 USER moonlight

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,9 @@ ENV WEBRTC_PORT_RANGE=40000:40100
 EXPOSE 8080 40000-40100/udp
 
 # Create an entrypoint
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY entrypoint.sh ${MOONLIGHT_WEB_PATH}/entrypoint.sh
+RUN chown moonlight:moonlight ${MOONLIGHT_WEB_PATH}/entrypoint.sh && \
+    chmod +x /entrypoint.sh
 
 # Switch to the non-root user
 USER moonlight

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,11 @@ FROM ubuntu:24.04
 
 ENV MOONLIGHT_WEB_PATH=/moonlight-web
 
+ARG GID=999
+ARG UID=999
+
 # Create a non-root user
-RUN groupadd -r moonlight && useradd -r -g moonlight -d ${MOONLIGHT_WEB_PATH} -s /sbin/nologin moonlight
+RUN groupadd -g ${GID} -r moonlight && useradd -u ${UID} -r -g moonlight -d ${MOONLIGHT_WEB_PATH} -s /sbin/nologin moonlight
 
 # Create / Go to app directory
 WORKDIR ${MOONLIGHT_WEB_PATH}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,4 +33,4 @@ RUN chown moonlight:moonlight ${MOONLIGHT_WEB_PATH}/entrypoint.sh && \
 USER moonlight
 
 # Run the binary
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["${MOONLIGHT_WEB_PATH}/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,8 @@ ADD https://github.com/MrCreativ3001/moonlight-web-stream/releases/latest/downlo
 RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ && \
     rm /tmp/app.tar.gz && \
     mkdir -p ${MOONLIGHT_WEB_PATH}/server && \
-    chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH}
+    chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH} && \
+    chmod +x ${MOONLIGHT_WEB_PATH}/web-server
 
 # Create a volume with the config.json and data.json
 VOLUME ${MOONLIGHT_WEB_PATH}/server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,15 +2,20 @@ FROM ubuntu:24.04
 
 ENV MOONLIGHT_WEB_PATH=/moonlight-web
 
+# Create a non-root user
+RUN groupadd -r moonlight && useradd -r -g moonlight -d ${MOONLIGHT_WEB_PATH} -s /sbin/nologin moonlight
+
 # Create / Go to app directory
 WORKDIR ${MOONLIGHT_WEB_PATH}
 
 # Download the release binary
 ADD https://github.com/MrCreativ3001/moonlight-web-stream/releases/latest/download/moonlight-web-x86_64-unknown-linux-gnu.tar.gz /tmp/app.tar.gz
 
-# Extract it
-RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ &&\
-    rm /tmp/app.tar.gz
+# Extract it, create server directory, and change ownership
+RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ && \
+    rm /tmp/app.tar.gz && \
+    mkdir -p ${MOONLIGHT_WEB_PATH}/server && \
+    chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH}
 
 # Create a volume with the config.json and data.json
 VOLUME ${MOONLIGHT_WEB_PATH}/server
@@ -22,6 +27,9 @@ EXPOSE 8080 40000-40100/udp
 # Create an entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Switch to the non-root user
+USER moonlight
 
 # Run the binary
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,8 @@ RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ && 
     rm /tmp/app.tar.gz && \
     mkdir -p ${MOONLIGHT_WEB_PATH}/server && \
     chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH} && \
-    chmod +x ${MOONLIGHT_WEB_PATH}/web-server
+    chmod +x ${MOONLIGHT_WEB_PATH}/web-server && \
+    chmod +x ${MOONLIGHT_WEB_PATH}/streamer
 
 # Create a volume with the config.json and data.json
 VOLUME ${MOONLIGHT_WEB_PATH}/server

--- a/docker/Dockerfile.action
+++ b/docker/Dockerfile.action
@@ -2,14 +2,19 @@ FROM ubuntu:24.04
 
 ENV MOONLIGHT_WEB_PATH=/moonlight-web
 
+# Create a non-root user
+RUN groupadd -r moonlight && useradd -r -g moonlight -d ${MOONLIGHT_WEB_PATH} -s /sbin/nologin moonlight
+
 # Create / Go to app directory
 WORKDIR ${MOONLIGHT_WEB_PATH}
 
 # Copy prebuilt artifacts
 COPY moonlight-web/ ${MOONLIGHT_WEB_PATH}/
 
-# Mark executables as executable
-RUN chmod +x ${MOONLIGHT_WEB_PATH}/streamer ${MOONLIGHT_WEB_PATH}/web-server
+# Mark executables as executable, create server directory, and change ownership
+RUN chmod +x ${MOONLIGHT_WEB_PATH}/streamer ${MOONLIGHT_WEB_PATH}/web-server && \
+    mkdir -p ${MOONLIGHT_WEB_PATH}/server && \
+    chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH}
 
 # Create a volume with the config.json and data.json
 VOLUME ${MOONLIGHT_WEB_PATH}/server
@@ -21,6 +26,9 @@ EXPOSE 8080 40000-40100/udp
 # Create an entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Switch to the non-root user
+USER moonlight
 
 # Run the binary
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.prerelease
+++ b/docker/Dockerfile.prerelease
@@ -2,15 +2,20 @@ FROM ubuntu:24.04
 
 ENV MOONLIGHT_WEB_PATH=/moonlight-web
 
+# Create a non-root user
+RUN groupadd -r moonlight && useradd -r -g moonlight -d ${MOONLIGHT_WEB_PATH} -s /sbin/nologin moonlight
+
 # Create / Go to app directory
 WORKDIR ${MOONLIGHT_WEB_PATH}
 
 # Download the release binary
 ADD https://github.com/MrCreativ3001/moonlight-web-stream/releases/download/v2.1-prerelease.1/moonlight-web-x86_64-unknown-linux-gnu.tar.gz /tmp/app.tar.gz
 
-# Extract it
-RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ &&\
-    rm /tmp/app.tar.gz
+# Extract it, create server directory, and change ownership
+RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ && \
+    rm /tmp/app.tar.gz && \
+    mkdir -p ${MOONLIGHT_WEB_PATH}/server && \
+    chown -R moonlight:moonlight ${MOONLIGHT_WEB_PATH}
 
 # Create a volume with the config.json and data.json
 VOLUME ${MOONLIGHT_WEB_PATH}/server
@@ -22,6 +27,9 @@ EXPOSE 8080 40000-40100/udp
 # Create an entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Switch to the non-root user
+USER moonlight
 
 # Run the binary
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This pull request adjusts the Dockerfile to create a user named moonlight and run the web-server and streamer binary as that user. 

The UID and GID are configurable by the user by specifying `user: $UID:$GID` at container creation time. A default of 999 was set for both the UID and GID. 

After a little trial and error it's working well for me (You can see that in my git commits). 

I'm not sure if I'm missing anything here so other testers would be appreciated!