### PR TITLE
Trigger auto fullscreen on first stream interaction

### DIFF
--- a/web/locales/en.ts
+++ b/web/locales/en.ts
@@ -78,7 +78,7 @@ export const en = {
         dataTransport: "Data Transport",
         auto: "Auto",
         webSocket: "Web Socket",
-        enterFullscreenOnStreamStart: "Prompt Fullscreen On Stream Start",
+        enterFullscreenOnStreamStart: "Enter Fullscreen On First Stream Interaction",
         saveRoleDefaults: "Save As Role Defaults",
         saveRoleDefaultsSuccess: "Saved current settings as role defaults",
         saveRoleDefaultsFailed: "Couldn't save role default settings",

--- a/web/locales/fr-FR.ts
+++ b/web/locales/fr-FR.ts
@@ -80,7 +80,7 @@ export const frFr: Translations = {
         dataTransport: "Transport des données",
         auto: "Auto",
         webSocket: "Web Socket",
-        enterFullscreenOnStreamStart: "Invite de mise en plein écran au démarrage de la diffusion",
+        enterFullscreenOnStreamStart: "Passer en plein écran à la première interaction avec la diffusion",
         saveRoleDefaults: "Enregistrer par défaut pour le rôle",
         saveRoleDefaultsSuccess: "Enregistré par défaut pour le rôle",
         saveRoleDefaultsFailed: "Echec de l'enregistrement des paramètres par défaut pour le rôle",

--- a/web/locales/ko-KR.ts
+++ b/web/locales/ko-KR.ts
@@ -80,7 +80,7 @@ export const koKR: Translations = {
         dataTransport: "데이터 전송 방식",
         auto: "자동",
         webSocket: "웹 소켓 (Web Socket)",
-        enterFullscreenOnStreamStart: "스트리밍 시작 시 전체 화면 전환 묻기",
+        enterFullscreenOnStreamStart: "스트림 첫 상호작용 시 전체 화면으로 전환",
         saveRoleDefaults: "현재 설정을 역할 기본값으로 저장",
         saveRoleDefaultsSuccess: "현재 설정을 역할 기본값으로 저장했습니다.",
         saveRoleDefaultsFailed: "역할 기본 설정을 저장하지 못했습니다.",

--- a/web/locales/pt-BR.ts
+++ b/web/locales/pt-BR.ts
@@ -80,7 +80,7 @@ export const ptBR: Translations = {
         dataTransport: "Transporte de Dados",
         auto: "Automático",
         webSocket: "WebSocket",
-        enterFullscreenOnStreamStart: "Perguntar sobre Tela Cheia ao Iniciar Stream",
+        enterFullscreenOnStreamStart: "Entrar em Tela Cheia na Primeira Interação com o Stream",
         saveRoleDefaults: "Salvar como Padrão do Perfil",
         saveRoleDefaultsSuccess: "Configurações salvas como padrão do perfil",
         saveRoleDefaultsFailed: "Não foi possível salvar as configurações padrão do perfil",

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -80,7 +80,7 @@ export const zhCN: Translations = {
         dataTransport: "传输方式",
         auto: "自动",
         webSocket: "WebSocket",
-        enterFullscreenOnStreamStart: "进入串流后弹窗全屏提示",
+        enterFullscreenOnStreamStart: "首次操作串流时进入全屏",
         saveRoleDefaults: "保存为当前角色默认设置",
         saveRoleDefaultsSuccess: "已将当前设置保存为当前角色默认",
         saveRoleDefaultsFailed: "保存角色默认设置失败",

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -522,7 +522,7 @@ class ViewerApp implements Component {
                 await navigator.keyboard.lock()
 
                 if (showEscapeWarning && !this.hasShownFullscreenEscapeWarning) {
-                    await showMessage(I.stream.fullscreenEscapeHint)
+                    showNotification(I.stream.fullscreenEscapeHint, "info")
                     this.hasShownFullscreenEscapeWarning = true
                 }
             }

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -256,7 +256,7 @@ class ViewerApp implements Component {
         }
 
         this.fullscreenOnNextInteractionArmed = false
-        void this.requestFullscreen(false).then(() => {
+        void this.requestFullscreen().then(() => {
             if (!this.isFullscreen()) {
                 this.armFullscreenOnNextInteraction()
             }

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -88,6 +88,10 @@ class ViewerApp implements Component {
     private autoEnterFullscreenOnStart: boolean = false
     private pendingAutoFullscreenPrompt: boolean = false
     private fullscreenPromptShown: boolean = false
+    private fullscreenOnNextInteractionArmed: boolean = false
+    private pendingAutoFullscreenTouchGesture: boolean = false
+    private pendingAutoFullscreenMouseGesture: boolean = false
+    private manualFullscreenExitRequested: boolean = false
     private toggleFullscreenWithKeybind: boolean = false
     private hasShownFullscreenEscapeWarning = false
 
@@ -199,7 +203,7 @@ class ViewerApp implements Component {
             if (this.autoEnterFullscreenOnStart && this.pendingAutoFullscreenPrompt && !this.fullscreenPromptShown && !this.isFullscreen()) {
                 this.fullscreenPromptShown = true
                 this.pendingAutoFullscreenPrompt = false
-                await this.promptAutoFullscreen()
+                this.armFullscreenOnNextInteraction()
             }
         })
 
@@ -240,6 +244,40 @@ class ViewerApp implements Component {
 
         this.stream.getVideoRenderer()?.onUserInteraction()
         this.stream.getAudioPlayer()?.onUserInteraction()
+    }
+    private armFullscreenOnNextInteraction() {
+        if (this.autoEnterFullscreenOnStart) {
+            this.fullscreenOnNextInteractionArmed = true
+        }
+    }
+    private consumeAutoFullscreenInteraction(): boolean {
+        if (!this.fullscreenOnNextInteractionArmed || this.isFullscreen()) {
+            return false
+        }
+
+        this.fullscreenOnNextInteractionArmed = false
+        void this.requestFullscreen(false).then(() => {
+            if (!this.isFullscreen()) {
+                this.armFullscreenOnNextInteraction()
+            }
+        })
+        return true
+    }
+    private beginAutoFullscreenTouchGesture(): boolean {
+        if (!this.fullscreenOnNextInteractionArmed || this.isFullscreen()) {
+            return false
+        }
+
+        this.pendingAutoFullscreenTouchGesture = true
+        return true
+    }
+    private consumeAutoFullscreenTouchGesture(): boolean {
+        if (!this.pendingAutoFullscreenTouchGesture) {
+            return false
+        }
+
+        this.pendingAutoFullscreenTouchGesture = false
+        return this.consumeAutoFullscreenInteraction()
     }
     private onScreenKeyboardSetVisible(event: ScreenKeyboardSetVisibleEvent) {
         console.info(event.detail)
@@ -321,6 +359,13 @@ class ViewerApp implements Component {
 
     // Mouse
     onMouseButtonDown(event: MouseEvent) {
+        if (this.consumeAutoFullscreenInteraction()) {
+            this.pendingAutoFullscreenMouseGesture = true
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         this.onUserInteraction()
 
         event.preventDefault()
@@ -329,6 +374,13 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onMouseButtonUp(event: MouseEvent) {
+        if (this.pendingAutoFullscreenMouseGesture) {
+            this.pendingAutoFullscreenMouseGesture = false
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         this.onUserInteraction()
 
         event.preventDefault()
@@ -337,6 +389,12 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onMouseMove(event: MouseEvent) {
+        if (this.pendingAutoFullscreenMouseGesture) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         event.preventDefault()
         this.stream.getInput().onMouseMove(event, this.getStreamRect())
 
@@ -356,6 +414,12 @@ class ViewerApp implements Component {
 
     // Touch
     onTouchStart(event: TouchEvent) {
+        if (this.beginAutoFullscreenTouchGesture()) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         this.onUserInteraction()
 
         event.preventDefault()
@@ -364,6 +428,12 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchEnd(event: TouchEvent) {
+        if (this.consumeAutoFullscreenTouchGesture()) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         this.onUserInteraction()
 
         event.preventDefault()
@@ -372,6 +442,15 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchCancel(event: TouchEvent) {
+        if (this.pendingAutoFullscreenTouchGesture) {
+            this.pendingAutoFullscreenTouchGesture = false
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
+        this.pendingAutoFullscreenTouchGesture = false
+
         this.onUserInteraction()
 
         event?.preventDefault()
@@ -386,6 +465,12 @@ class ViewerApp implements Component {
         window.requestAnimationFrame(this.onTouchUpdate.bind(this))
     }
     onTouchMove(event: TouchEvent) {
+        if (this.pendingAutoFullscreenTouchGesture) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+        }
+
         event.preventDefault()
         this.stream.getInput().onTouchMove(event, this.getStreamRect())
 
@@ -412,7 +497,7 @@ class ViewerApp implements Component {
     private async promptAutoFullscreen() {
         await showModal(new AutoFullscreenModal(this.requestFullscreen.bind(this)))
     }
-    async requestFullscreen() {
+    async requestFullscreen(showEscapeWarning: boolean = true) {
         const body = document.body
         if (body) {
             if (!("requestFullscreen" in body && typeof body.requestFullscreen == "function")) {
@@ -436,10 +521,10 @@ class ViewerApp implements Component {
             if ("keyboard" in navigator && navigator.keyboard && "lock" in navigator.keyboard) {
                 await navigator.keyboard.lock()
 
-                if (!this.hasShownFullscreenEscapeWarning) {
+                if (showEscapeWarning && !this.hasShownFullscreenEscapeWarning) {
                     await showMessage(I.stream.fullscreenEscapeHint)
+                    this.hasShownFullscreenEscapeWarning = true
                 }
-                this.hasShownFullscreenEscapeWarning = true
             }
 
             if (this.getStream()?.getInput().getConfig().mouseMode == "relative") {
@@ -474,7 +559,24 @@ class ViewerApp implements Component {
         return "fullscreenElement" in document && !!document.fullscreenElement
     }
     private async onFullscreenChange() {
+        if (this.isFullscreen()) {
+            this.fullscreenOnNextInteractionArmed = false
+            this.pendingAutoFullscreenTouchGesture = false
+            this.pendingAutoFullscreenMouseGesture = false
+            this.manualFullscreenExitRequested = false
+        } else {
+            const manualExit = this.manualFullscreenExitRequested
+            this.manualFullscreenExitRequested = false
+
+            if (this.autoEnterFullscreenOnStart && !manualExit) {
+                this.armFullscreenOnNextInteraction()
+            }
+        }
+
         this.checkFullyImmersed()
+    }
+    markManualFullscreenExitRequested() {
+        this.manualFullscreenExitRequested = true
     }
 
     // Pointer Lock
@@ -806,6 +908,7 @@ class ViewerSidebar implements Component, Sidebar {
         this.fullscreenButton.innerText = I.stream.fullscreen
         this.fullscreenButton.addEventListener("click", async () => {
             if (this.app.isFullscreen()) {
+                this.app.markManualFullscreenExitRequested()
                 await this.app.exitFullscreen()
             } else {
                 await this.app.requestFullscreen()


### PR DESCRIPTION
## Summary

This PR adjusts the auto fullscreen behavior so fullscreen is requested on the first stream interaction instead of showing a prompt immediately after the stream starts.

This better matches browser fullscreen requirements, because fullscreen requests need to be tied to a user gesture.

## Changes

- Arm auto fullscreen after the stream starts instead of immediately showing the fullscreen prompt.
- Request fullscreen on the first mouse/touch interaction with the stream.
- Prevent that first fullscreen-triggering interaction from also being sent to the remote host.
- Re-arm auto fullscreen after non-manual fullscreen exits.
- Treat exits from the sidebar fullscreen button as manual exits.
- Update the setting label translations to match the new behavior.

## Open question

After entering fullscreen, the current ESC hint is shown through a blocking confirmation modal:

> To exit Fullscreen you'll have to hold ESC for a few seconds.

Would you prefer changing this hint to a non-blocking notification/toast instead, so it does not require manual confirmation?

I did not include that behavior change in this PR because it changes the notification style and should probably be decided separately.

## Testing

- Tested auto fullscreen on first stream interaction.
- Tested that the first fullscreen-triggering touch does not leak to the remote host.
- Ran `npm run build-light`.
