### PR TITLE
Close connection modal after video is ready

### DIFF
--- a/web/stream.ts
+++ b/web/stream.ts
@@ -648,6 +648,7 @@ class ConnectionInfoModal implements Modal<void> {
             const text = I.stream.connectionComplete
             this.text.innerText = text
             this.debugLog(text)
+        } else if (data.type == "videoReady") {
 
             this.eventTarget.dispatchEvent(new Event("ml-connected"))
         } else if (data.type == "addDebugLine") {
@@ -670,8 +671,6 @@ class ConnectionInfoModal implements Modal<void> {
 
             if (data.additional?.type == "fatal" || data.additional?.type == "fatalDescription") {
                 showModal(this)
-            } else if (data.additional?.type == "recover") {
-                showModal(null)
             } else if (data.additional?.type == "informError") {
                 showErrorPopup(data.line)
             }

--- a/web/stream/index.ts
+++ b/web/stream/index.ts
@@ -26,6 +26,7 @@ export type InfoEvent = CustomEvent<
     { type: "app", app: App } |
     { type: "serverMessage", message: string } |
     { type: "connectionComplete", capabilities: StreamCapabilities } |
+    { type: "videoReady" } |
     { type: "connectionStatus", status: ConnectionStatus } |
     { type: "addDebugLine", line: string, additional?: LogMessageInfo }
 >
@@ -114,6 +115,9 @@ export class Stream implements Component {
     private stats: StreamStats
 
     private streamerSize: [number, number]
+    private hasConnectionComplete = false
+    private hasVideoReady = false
+    private hasDispatchedVideoReady = false
 
     constructor(api: Api, hostId: number, appId: number, settings: Settings, viewerScreenSize: [number, number], permissions: StreamPermissions) {
         this.logger.addInfoListener((info, type) => {
@@ -156,6 +160,30 @@ export class Stream implements Component {
 
             this.eventTarget.dispatchEvent(event)
         }
+    }
+    private resetVideoReadyState() {
+        this.hasConnectionComplete = false
+        this.hasVideoReady = false
+        this.hasDispatchedVideoReady = false
+    }
+    private markConnectionComplete() {
+        this.hasConnectionComplete = true
+        this.tryDispatchVideoReady()
+    }
+    private markVideoReady() {
+        this.hasVideoReady = true
+        this.tryDispatchVideoReady()
+    }
+    private tryDispatchVideoReady() {
+        if (!this.hasConnectionComplete || !this.hasVideoReady || this.hasDispatchedVideoReady) {
+            return
+        }
+
+        this.hasDispatchedVideoReady = true
+        const event: InfoEvent = new CustomEvent("stream-info", {
+            detail: { type: "videoReady" }
+        })
+        this.eventTarget.dispatchEvent(event)
     }
 
     private async onMessage(message: StreamServerMessage) {
@@ -232,6 +260,8 @@ export class Stream implements Component {
                     mapping: audioMapping,
                 })
             ])
+
+            this.markConnectionComplete()
         } else if ("ConnectionTerminated" in message) {
             const code = message.ConnectionTerminated.error_code
 
@@ -329,6 +359,7 @@ export class Stream implements Component {
     }
     private async restartWithFreshTransportFallback(transport: TransportType): Promise<void> {
         this.transportOverride = transport
+        this.resetVideoReadyState()
 
         if (this.transport) {
             await this.transport.close()
@@ -637,6 +668,7 @@ export class Stream implements Component {
             videoRenderer.mount(this.divElement)
 
             video.addTrackListener((track) => {
+                this.markVideoReady()
                 videoRenderer.setTrack(track)
             })
 
@@ -652,6 +684,7 @@ export class Stream implements Component {
             videoRenderer.mount(this.divElement)
 
             video.addReceiveListener((data) => {
+                this.markVideoReady()
                 videoRenderer.submitPacket(data)
 
                 // data pipeline support requesting idrs over video channel


### PR DESCRIPTION
## Summary

This PR delays closing the connection modal until the stream connection is complete and video data is available.

In auto transport mode, the previous close timing could make the modal disappear before the video path was actually ready, leaving a black screen period with no connection progress visible.

## Changes

- Add a `videoReady` stream-info event.
- Track both connection completion and video readiness before dispatching the final connected event.
- Mark video readiness when a video track or video data is received.
- Reset readiness state when restarting with transport fallback.
- Avoid hiding the connection modal during recover/fallback status handling.

## Notes

This is a more stable close point, but it is still not a perfect "first frame rendered" signal.

The modal now waits until the stream has both completed the connection stage and received video track/data, which avoids the most obvious early-close case. However, there can still be a short delay between receiving video data and the browser actually rendering the first visible frame.

A more precise solution would likely need a renderer-level signal, such as detecting the first rendered video frame, but this PR keeps the change smaller and closer to the existing stream event flow.

## Testing

- Tested auto transport fallback behavior.
- Verified the connection modal stays visible until the stream is closer to video output.
- Ran `npm run build-light`.
