### PR TITLE
Use decoded video size for stream rect calculation

### DIFF
--- a/web/stream/video/video_element.ts
+++ b/web/stream/video/video_element.ts
@@ -127,12 +127,22 @@ export class VideoElementRenderer implements TrackVideoRenderer, VideoRenderer {
             })
         }
     }
+    private getEffectiveVideoSize(): [number, number] | null {
+        const width = this.videoElement.videoWidth
+        const height = this.videoElement.videoHeight
+        if (width > 0 && height > 0) {
+            return [width, height]
+        }
+
+        return this.size
+    }
     getStreamRect(): DOMRect {
-        if (!this.size) {
+        const effectiveSize = this.getEffectiveVideoSize()
+        if (!effectiveSize) {
             return new DOMRect()
         }
 
-        return getStreamRectCorrected(this.videoElement.getBoundingClientRect(), this.size)
+        return getStreamRectCorrected(this.videoElement.getBoundingClientRect(), effectiveSize)
     }
 
     getBase(): Pipe | null {
@@ -219,12 +229,22 @@ export class UrlVideoElementRenderer implements UrlVideoRenderer, VideoRenderer 
             })
         }
     }
+    private getEffectiveVideoSize(): [number, number] | null {
+        const width = this.videoElement.videoWidth
+        const height = this.videoElement.videoHeight
+        if (width > 0 && height > 0) {
+            return [width, height]
+        }
+
+        return this.size
+    }
     getStreamRect(): DOMRect {
-        if (!this.size) {
+        const effectiveSize = this.getEffectiveVideoSize()
+        if (!effectiveSize) {
             return new DOMRect()
         }
 
-        return getStreamRectCorrected(this.videoElement.getBoundingClientRect(), this.size)
+        return getStreamRectCorrected(this.videoElement.getBoundingClientRect(), effectiveSize)
     }
 
     getBase(): Pipe | null {


### PR DESCRIPTION
## Summary

This PR uses the decoded video element size when calculating the visible stream rectangle.

This helps input mapping and local cursor behavior when the actual decoded video size differs from the requested stream size.

## Changes

- Read `videoWidth` and `videoHeight` from the video element when available.
- Use the decoded video size for `getStreamRectCorrected`.
- Fall back to the configured renderer size when decoded dimensions are not available yet.
- Apply the same logic to both `VideoElementRenderer` and `UrlVideoElementRenderer`.

## Notes

This improves the frontend mapping basis, but it does not attempt to detect the effective content area inside the video when the host or encoder adds letterboxing/pillarboxing.

## Testing

- Tested local cursor / touch mapping with a stream whose decoded dimensions differed from the requested dimensions.
- Ran `npm run build-light`.
