### PR TITLE
fix navigator.keyboard.lock in iframe environments

### DIFF
--- a/web/iframe.ts
+++ b/web/iframe.ts
@@ -1,0 +1,36 @@
+
+export function requestKeyboardLock(keys?: string[]): Promise<void> {
+    const topWindow = window.top;
+    let lockerFunc: ((keys?: string[]) => Promise<void>) | undefined;
+
+    if (window.self === topWindow) {
+        if (navigator.keyboard?.lock) {
+            lockerFunc = navigator.keyboard.lock.bind(navigator.keyboard);
+        }
+    } else if (topWindow) {
+        let sameOrigin = false;
+        try {
+            sameOrigin = window.location.origin === topWindow.location.origin;
+        } catch (e) {
+            sameOrigin = false;
+        }
+
+        if (sameOrigin) {
+            if (topWindow.navigator.keyboard?.lock) {
+                lockerFunc = topWindow.navigator.keyboard.lock.bind(topWindow.navigator.keyboard);
+            }
+        } else {
+            lockerFunc = (k) => {
+                const requestId = Math.random().toString(36).substring(2, 9);
+                window.parent.postMessage({ type: "REQUEST_KEYBOARD_LOCK", requestId, keys: k }, "*");
+                return Promise.resolve();
+            };
+        }
+    }
+
+    if (!lockerFunc) {
+        return Promise.resolve();
+    }
+
+    return lockerFunc(keys);
+}

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -13,6 +13,7 @@ import { ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
 import { FormModal } from "./component/modal/form.js";
 import { streamStatsToText } from "./stream/stats.js";
 import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations } from "./i18n.js";
+import {requestKeyboardLock} from "./iframe.js";
 
 let I = getTranslations(getCurrentLanguage())
 
@@ -518,13 +519,14 @@ class ViewerApp implements Component {
                 }
             }
 
-            if ("keyboard" in navigator && navigator.keyboard && "lock" in navigator.keyboard) {
-                await navigator.keyboard.lock()
-
-                if (showEscapeWarning && !this.hasShownFullscreenEscapeWarning) {
+            try {
+                await requestKeyboardLock();
+                  if (showEscapeWarning && !this.hasShownFullscreenEscapeWarning) {
                     showNotification(I.stream.fullscreenEscapeHint, "info")
                     this.hasShownFullscreenEscapeWarning = true
                 }
+            } catch (e) {
+                console.warn("Keyboard lock failed, skipping notification.", e);
             }
 
             if (this.getStream()?.getInput().getConfig().mouseMode == "relative") {


### PR DESCRIPTION
This PR handles the keyboard lock request for iframe environments (same-origin, cross-domain, and top-level).

I’ve closed #124 and opened this new one to align with the recent changes in fullscreen logic. Since the UI has shifted from modal dialogs to notifications, the implementation is now much simpler and cleaner than the previous version.