### PR TITLE
Improve mobile screen keyboard handling

### DIFF
--- a/web/locales/en.ts
+++ b/web/locales/en.ts
@@ -22,6 +22,7 @@ export const en = {
         sendKeycode: "Send Keycode",
         lockMouse: "Lock Mouse",
         keyboard: "Keyboard",
+        hideKeyboard: "Hide Keyboard",
         fullscreen: "Fullscreen",
         stats: "Stats",
         exit: "Exit",

--- a/web/locales/fr-FR.ts
+++ b/web/locales/fr-FR.ts
@@ -24,6 +24,7 @@ export const frFr: Translations = {
         sendKeycode: "Envoiyer le code clé",
         lockMouse: "Verrouillage de la souris",
         keyboard: "Clavier",
+        hideKeyboard: "Masquer le clavier",
         fullscreen: "Plein écran",
         stats: "Stats",
         exit: "Quitter",

--- a/web/locales/ko-KR.ts
+++ b/web/locales/ko-KR.ts
@@ -24,6 +24,7 @@ export const koKR: Translations = {
         sendKeycode: "키코드 전송",
         lockMouse: "마우스 가두기",
         keyboard: "키보드",
+        hideKeyboard: "키보드 숨기기",
         fullscreen: "전체 화면",
         stats: "통계",
         exit: "종료",

--- a/web/locales/pt-BR.ts
+++ b/web/locales/pt-BR.ts
@@ -24,6 +24,7 @@ export const ptBR: Translations = {
         sendKeycode: "Enviar Código de Tecla",
         lockMouse: "Bloquear Mouse",
         keyboard: "Teclado",
+        hideKeyboard: "Ocultar Teclado",
         fullscreen: "Tela Cheia",
         stats: "Estatísticas",
         exit: "Sair",

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -24,6 +24,7 @@ export const zhCN: Translations = {
         sendKeycode: "发送按键码",
         lockMouse: "锁定鼠标",
         keyboard: "键盘",
+        hideKeyboard: "隐藏键盘",
         fullscreen: "全屏",
         stats: "统计",
         exit: "退出",

--- a/web/screen_keyboard.ts
+++ b/web/screen_keyboard.ts
@@ -1,5 +1,6 @@
 
 export type TextEvent = CustomEvent<{ text: string }>
+export type KeyboardModeEvent = CustomEvent<{ enabled: boolean }>
 
 const KEYBOARD_SENTINEL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -8,7 +9,7 @@ export class ScreenKeyboard {
     private eventTarget = new EventTarget()
     private fakeElement = document.createElement("textarea")
 
-    private visible: boolean = false
+    private enabled: boolean = false
 
     constructor() {
         this.fakeElement.classList.add("hiddeninput")
@@ -24,8 +25,7 @@ export class ScreenKeyboard {
         this.fakeElement.addEventListener("input", this.onKeyInput.bind(this))
         this.fakeElement.addEventListener("compositionend", this.onCompositionEnd.bind(this))
 
-        document.addEventListener("click", this.hide.bind(this))
-        this.fakeElement.addEventListener("blur", this.hide.bind(this))
+        document.addEventListener("click", this.refocusIfEnabled.bind(this))
     }
 
     getHiddenElement() {
@@ -33,24 +33,39 @@ export class ScreenKeyboard {
     }
 
     show() {
-        if (!this.visible) {
-            this.visible = true
-
-            this.resetInputValue()
-            this.fakeElement.focus()
-        }
+        this.setEnabled(true)
     }
     hide() {
-        if (this.visible) {
-            this.visible = false
-
-            this.fakeElement.focus()
-            this.fakeElement.blur()
-        }
+        this.setEnabled(false)
     }
 
     isVisible(): boolean {
-        return this.visible
+        return this.enabled
+    }
+    private setEnabled(enabled: boolean) {
+        const changed = this.enabled != enabled
+        this.enabled = enabled
+
+        if (enabled) {
+            this.refocusIfEnabled()
+        } else if (document.activeElement === this.fakeElement) {
+            this.fakeElement.blur()
+        }
+
+        if (changed) {
+            const event: KeyboardModeEvent = new CustomEvent("ml-keyboardmode", {
+                detail: { enabled }
+            })
+            this.eventTarget.dispatchEvent(event)
+        }
+    }
+    private refocusIfEnabled() {
+        if (!this.enabled || document.activeElement === this.fakeElement) {
+            return
+        }
+
+        this.resetInputValue()
+        this.fakeElement.focus()
     }
 
     addKeyDownListener(listener: (event: KeyboardEvent) => void) {
@@ -61,6 +76,9 @@ export class ScreenKeyboard {
     }
     addTextListener(listener: (event: TextEvent) => void) {
         this.eventTarget.addEventListener("ml-text", listener as any)
+    }
+    addKeyboardModeListener(listener: (event: KeyboardModeEvent) => void) {
+        this.eventTarget.addEventListener("ml-keyboardmode", listener as any)
     }
 
     // -- Events

--- a/web/screen_keyboard.ts
+++ b/web/screen_keyboard.ts
@@ -1,16 +1,17 @@
 
 export type TextEvent = CustomEvent<{ text: string }>
 
+const KEYBOARD_SENTINEL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
 export class ScreenKeyboard {
 
     private eventTarget = new EventTarget()
-    private fakeElement = document.createElement("input")
+    private fakeElement = document.createElement("textarea")
 
     private visible: boolean = false
 
     constructor() {
         this.fakeElement.classList.add("hiddeninput")
-        this.fakeElement.type = "text"
         this.fakeElement.name = "keyboard"
         this.fakeElement.autocomplete = "off"
         this.fakeElement.autocapitalize = "off"
@@ -18,8 +19,10 @@ export class ScreenKeyboard {
         if ("autocorrect" in this.fakeElement) {
             this.fakeElement.autocorrect = false
         }
+        this.resetInputValue()
 
         this.fakeElement.addEventListener("input", this.onKeyInput.bind(this))
+        this.fakeElement.addEventListener("compositionend", this.onCompositionEnd.bind(this))
 
         document.addEventListener("click", this.hide.bind(this))
         this.fakeElement.addEventListener("blur", this.hide.bind(this))
@@ -33,6 +36,7 @@ export class ScreenKeyboard {
         if (!this.visible) {
             this.visible = true
 
+            this.resetInputValue()
             this.fakeElement.focus()
         }
     }
@@ -60,6 +64,60 @@ export class ScreenKeyboard {
     }
 
     // -- Events
+    private resetInputValue() {
+        this.fakeElement.value = KEYBOARD_SENTINEL
+        this.fakeElement.setSelectionRange(KEYBOARD_SENTINEL.length, KEYBOARD_SENTINEL.length)
+    }
+    private dispatchText(text: string) {
+        const customEvent: TextEvent = new CustomEvent("ml-text", {
+            detail: { text }
+        })
+
+        this.eventTarget.dispatchEvent(customEvent)
+    }
+    private dispatchKey(code: string) {
+        const keyDown = new KeyboardEvent("keydown", { code })
+        const keyUp = new KeyboardEvent("keyup", { code })
+
+        this.eventTarget.dispatchEvent(keyDown)
+        this.eventTarget.dispatchEvent(keyUp)
+    }
+    private dispatchTextWithLineBreaks(text: string) {
+        const parts = text.split(/\r\n|\r|\n/)
+        parts.forEach((part, index) => {
+            if (part) {
+                this.dispatchText(part)
+            }
+            if (index < parts.length - 1) {
+                this.dispatchKey("Enter")
+            }
+        })
+    }
+    private extractInsertedText(): string {
+        const value = this.fakeElement.value
+        if (value == KEYBOARD_SENTINEL) {
+            return ""
+        }
+        if (value.startsWith(KEYBOARD_SENTINEL)) {
+            return value.slice(KEYBOARD_SENTINEL.length)
+        }
+        if (value.endsWith(KEYBOARD_SENTINEL)) {
+            return value.slice(0, -KEYBOARD_SENTINEL.length)
+        }
+        if (value.includes(KEYBOARD_SENTINEL)) {
+            return value.replace(KEYBOARD_SENTINEL, "")
+        }
+
+        return value
+    }
+    private onCompositionEnd() {
+        const text = this.extractInsertedText()
+        if (text) {
+            this.dispatchTextWithLineBreaks(text)
+        }
+
+        this.resetInputValue()
+    }
     private onKeyInput(event: Event) {
         if (!(event instanceof InputEvent)) {
             return
@@ -68,35 +126,22 @@ export class ScreenKeyboard {
             return
         }
 
-        if ((event.inputType == "insertText" || event.inputType == "insertFromPaste") && event.data != null) {
-            const customEvent: TextEvent = new CustomEvent("ml-text", {
-                detail: { text: event.data }
-            })
-
-            this.eventTarget.dispatchEvent(customEvent)
+        if (event.inputType == "insertLineBreak" || event.inputType == "insertParagraph") {
+            this.dispatchKey("Enter")
+        } else if ((event.inputType == "insertText" || event.inputType == "insertFromPaste" || event.inputType == "insertReplacementText") && event.data != null) {
+            this.dispatchTextWithLineBreaks(event.data)
         } else if (event.inputType == "deleteContentBackward" || event.inputType == "deleteByCut") {
-            const keyDown = new KeyboardEvent("keydown", {
-                code: "Backspace"
-            })
-            const keyUp = new KeyboardEvent("keyup", {
-                code: "Backspace"
-            })
-
-            this.eventTarget.dispatchEvent(keyDown)
-            this.eventTarget.dispatchEvent(keyUp)
+            this.dispatchKey("Backspace")
         } else if (event.inputType == "deleteContentForward") {
-            const keyDown = new KeyboardEvent("keydown", {
-                code: "Delete"
-            })
-            const keyUp = new KeyboardEvent("keyup", {
-                code: "Delete"
-            })
-
-            this.eventTarget.dispatchEvent(keyDown)
-            this.eventTarget.dispatchEvent(keyUp)
+            this.dispatchKey("Delete")
+        } else {
+            const text = this.extractInsertedText()
+            if (text) {
+                this.dispatchTextWithLineBreaks(text)
+            }
         }
 
         // Repopulate the input so that the deleteContent commands will work
-        this.fakeElement.value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        this.resetInputValue()
     }
 }

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -9,7 +9,7 @@ import { defaultStreamInputConfig, MouseMode, ScreenKeyboardSetVisibleEvent, Str
 import { getLocalStreamSettings, Settings } from "./component/settings_menu.js";
 import { SelectComponent } from "./component/input.js";
 import { DetailedRole, LogMessageType, StreamCapabilities, StreamKeys, StreamPermissions } from "./api_bindings.js";
-import { ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
+import { KeyboardModeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
 import { FormModal } from "./component/modal/form.js";
 import { streamStatsToText } from "./stream/stats.js";
 import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations } from "./i18n.js";
@@ -851,6 +851,7 @@ class ViewerSidebar implements Component, Sidebar {
     private sendKeycodeButton = document.createElement("button")
 
     private keyboardButton = document.createElement("button")
+    private floatingKeyboardButton = document.createElement("button")
     private screenKeyboard = new ScreenKeyboard()
 
     private lockMouseButton = document.createElement("button")
@@ -900,9 +901,20 @@ class ViewerSidebar implements Component, Sidebar {
         })
         this.buttonDiv.appendChild(this.keyboardButton)
 
+        this.floatingKeyboardButton.innerText = "⌨×"
+        this.floatingKeyboardButton.title = I.stream.hideKeyboard
+        this.floatingKeyboardButton.ariaLabel = I.stream.hideKeyboard
+        this.floatingKeyboardButton.classList.add("stream-keyboard-floating-button")
+        this.floatingKeyboardButton.addEventListener("click", event => {
+            event.preventDefault()
+            event.stopPropagation()
+            this.screenKeyboard.hide()
+        })
+        stopPropagationOn(this.floatingKeyboardButton)
         this.screenKeyboard.addKeyDownListener(this.onKeyDown.bind(this))
         this.screenKeyboard.addKeyUpListener(this.onKeyUp.bind(this))
         this.screenKeyboard.addTextListener(this.onText.bind(this))
+        this.screenKeyboard.addKeyboardModeListener(this.onKeyboardModeChange.bind(this))
         this.div.appendChild(this.screenKeyboard.getHiddenElement())
 
 
@@ -993,6 +1005,13 @@ class ViewerSidebar implements Component, Sidebar {
     private onKeyUp(event: KeyboardEvent) {
         this.app.getStream()?.getInput().onKeyUp(event)
     }
+    private onKeyboardModeChange(event: KeyboardModeEvent) {
+        if (event.detail.enabled) {
+            this.floatingKeyboardButton.classList.add("visible")
+        } else {
+            this.floatingKeyboardButton.classList.remove("visible")
+        }
+    }
 
     // -- Mouse Mode
     private onMouseModeChange() {
@@ -1017,9 +1036,14 @@ class ViewerSidebar implements Component, Sidebar {
 
     mount(parent: HTMLElement): void {
         parent.appendChild(this.div)
+        const appRoot = document.getElementById("root")
+        ;(appRoot ?? document.body).appendChild(this.floatingKeyboardButton)
     }
     unmount(parent: HTMLElement): void {
         parent.removeChild(this.div)
+        if (this.floatingKeyboardButton.parentElement) {
+            this.floatingKeyboardButton.parentElement.removeChild(this.floatingKeyboardButton)
+        }
     }
 }
 

--- a/web/styles/moonlight.css
+++ b/web/styles/moonlight.css
@@ -882,6 +882,38 @@ canvas.video-stream {
     translate: 200vw 200vh;
 }
 
+.stream-keyboard-floating-button {
+    position: fixed;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    z-index: 1000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--accent-cyan);
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.55);
+    color: var(--text-1);
+    font-size: 18px;
+    opacity: 0.78;
+    cursor: pointer;
+    contain: layout paint style;
+    touch-action: none;
+    will-change: transform;
+}
+
+.stream-keyboard-floating-button.visible {
+    display: flex;
+}
+
+.stream-keyboard-floating-button:active {
+    opacity: 1;
+    transform: translateY(-50%) scale(0.95);
+}
+
 /* Prevent starting animation for elements */
 .prevent-start-transition {
     transition: none;

--- a/web/styles/standard.css
+++ b/web/styles/standard.css
@@ -1277,6 +1277,38 @@ canvas.video-stream {
     translate: 200vw 200vh;
 }
 
+.stream-keyboard-floating-button {
+    position: fixed;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    z-index: 1000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--accent-cyan);
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.55);
+    color: var(--text-1);
+    font-size: 18px;
+    opacity: 0.78;
+    cursor: pointer;
+    contain: layout paint style;
+    touch-action: none;
+    will-change: transform;
+}
+
+.stream-keyboard-floating-button.visible {
+    display: flex;
+}
+
+.stream-keyboard-floating-button:active {
+    opacity: 1;
+    transform: translateY(-50%) scale(0.95);
+}
+
 /* Prevent starting animation for elements */
 .prevent-start-transition {
     transition: none;


### PR DESCRIPTION
## Summary

This PR improves mobile soft-keyboard handling for the stream page.

Changes included:
- Switch the hidden keyboard capture element to a textarea-backed flow so Enter / multiline input can be handled explicitly.
- Keep keyboard mode as application-controlled state instead of treating system keyboard blur, Done, or close actions as authoritative.
- Add a small floating in-stream keyboard button to explicitly exit keyboard mode while keeping the existing sidebar Keyboard button as the open-only entry point.
- Improve fallback text extraction for IME, voice input, and replacement-text flows by comparing against a sentinel value when `InputEvent.data` is not enough.
- Add localized labels for the floating hide-keyboard control.

## Notes

The floating button is intentionally mounted outside the sidebar content so it remains available while the sidebar is collapsed. It also stops event propagation so tapping it does not send input to the remote stream.

This PR does not yet address stream viewport resizing while the system keyboard is open. That should be handled separately so the visible stream area can follow the current cursor / interaction position without mixing layout policy into the input-capture change.

## Testing

- Ran `npm run build-light` successfully.
- Tested on a router-deployed build during development.
- Verified the sidebar Keyboard button opens keyboard mode and the floating in-stream button closes it.