### PR TITLE
Draft: prototype keyboard viewport adjustment

### DIFF
--- a/web/screen_keyboard.ts
+++ b/web/screen_keyboard.ts
@@ -1,6 +1,7 @@
 
 export type TextEvent = CustomEvent<{ text: string }>
 export type KeyboardModeEvent = CustomEvent<{ enabled: boolean }>
+export type KeyboardDebugEvent = CustomEvent<{ label: string, data?: unknown }>
 
 const KEYBOARD_SENTINEL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -33,9 +34,11 @@ export class ScreenKeyboard {
     }
 
     show() {
+        this.debug("show")
         this.setEnabled(true)
     }
     hide() {
+        this.debug("hide")
         this.setEnabled(false)
     }
 
@@ -49,6 +52,7 @@ export class ScreenKeyboard {
         if (enabled) {
             this.refocusIfEnabled()
         } else if (document.activeElement === this.fakeElement) {
+            this.debug("blur-before-hide")
             this.fakeElement.blur()
         }
 
@@ -61,11 +65,21 @@ export class ScreenKeyboard {
     }
     private refocusIfEnabled() {
         if (!this.enabled || document.activeElement === this.fakeElement) {
+            this.debug("refocus-skipped", {
+                enabled: this.enabled,
+                activeElement: describeElement(document.activeElement)
+            })
             return
         }
 
         this.resetInputValue()
+        this.debug("focus-before-refocus", {
+            activeElement: describeElement(document.activeElement)
+        })
         this.fakeElement.focus()
+        this.debug("focus-after-refocus", {
+            activeElement: describeElement(document.activeElement)
+        })
     }
 
     addKeyDownListener(listener: (event: KeyboardEvent) => void) {
@@ -79,6 +93,9 @@ export class ScreenKeyboard {
     }
     addKeyboardModeListener(listener: (event: KeyboardModeEvent) => void) {
         this.eventTarget.addEventListener("ml-keyboardmode", listener as any)
+    }
+    addDebugListener(listener: (event: KeyboardDebugEvent) => void) {
+        this.eventTarget.addEventListener("ml-keyboarddebug", listener as any)
     }
 
     // -- Events
@@ -129,6 +146,10 @@ export class ScreenKeyboard {
         return value
     }
     private onCompositionEnd() {
+        this.debug("compositionend", {
+            valueLength: this.fakeElement.value.length,
+            activeElement: describeElement(document.activeElement)
+        })
         const text = this.extractInsertedText()
         if (text) {
             this.dispatchTextWithLineBreaks(text)
@@ -140,6 +161,13 @@ export class ScreenKeyboard {
         if (!(event instanceof InputEvent)) {
             return
         }
+        this.debug("input", {
+            inputType: event.inputType,
+            data: event.data,
+            isComposing: event.isComposing,
+            valueLength: this.fakeElement.value.length,
+            activeElement: describeElement(document.activeElement)
+        })
         if (event.isComposing) {
             return
         }
@@ -162,4 +190,21 @@ export class ScreenKeyboard {
         // Repopulate the input so that the deleteContent commands will work
         this.resetInputValue()
     }
+
+    private debug(label: string, data?: unknown) {
+        const event: KeyboardDebugEvent = new CustomEvent("ml-keyboarddebug", {
+            detail: { label, data }
+        })
+        this.eventTarget.dispatchEvent(event)
+    }
+}
+
+function describeElement(element: Element | null): string {
+    if (!element) {
+        return "null"
+    }
+
+    const id = element.id ? `#${element.id}` : ""
+    const className = element instanceof HTMLElement && element.className ? `.${element.className}` : ""
+    return `${element.tagName}${id}${className}`
 }

--- a/web/screen_keyboard.ts
+++ b/web/screen_keyboard.ts
@@ -1,7 +1,7 @@
 
 export type TextEvent = CustomEvent<{ text: string }>
 export type KeyboardModeEvent = CustomEvent<{ enabled: boolean }>
-export type KeyboardDebugEvent = CustomEvent<{ label: string, data?: unknown }>
+export type KeyboardModeWillChangeEvent = CustomEvent<{ enabled: boolean }>
 
 const KEYBOARD_SENTINEL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -34,11 +34,9 @@ export class ScreenKeyboard {
     }
 
     show() {
-        this.debug("show")
         this.setEnabled(true)
     }
     hide() {
-        this.debug("hide")
         this.setEnabled(false)
     }
 
@@ -47,12 +45,18 @@ export class ScreenKeyboard {
     }
     private setEnabled(enabled: boolean) {
         const changed = this.enabled != enabled
+        if (changed) {
+            const event: KeyboardModeWillChangeEvent = new CustomEvent("ml-keyboardmodewillchange", {
+                detail: { enabled }
+            })
+            this.eventTarget.dispatchEvent(event)
+        }
+
         this.enabled = enabled
 
         if (enabled) {
             this.refocusIfEnabled()
         } else if (document.activeElement === this.fakeElement) {
-            this.debug("blur-before-hide")
             this.fakeElement.blur()
         }
 
@@ -65,21 +69,11 @@ export class ScreenKeyboard {
     }
     private refocusIfEnabled() {
         if (!this.enabled || document.activeElement === this.fakeElement) {
-            this.debug("refocus-skipped", {
-                enabled: this.enabled,
-                activeElement: describeElement(document.activeElement)
-            })
             return
         }
 
         this.resetInputValue()
-        this.debug("focus-before-refocus", {
-            activeElement: describeElement(document.activeElement)
-        })
         this.fakeElement.focus()
-        this.debug("focus-after-refocus", {
-            activeElement: describeElement(document.activeElement)
-        })
     }
 
     addKeyDownListener(listener: (event: KeyboardEvent) => void) {
@@ -94,8 +88,8 @@ export class ScreenKeyboard {
     addKeyboardModeListener(listener: (event: KeyboardModeEvent) => void) {
         this.eventTarget.addEventListener("ml-keyboardmode", listener as any)
     }
-    addDebugListener(listener: (event: KeyboardDebugEvent) => void) {
-        this.eventTarget.addEventListener("ml-keyboarddebug", listener as any)
+    addKeyboardModeWillChangeListener(listener: (event: KeyboardModeWillChangeEvent) => void) {
+        this.eventTarget.addEventListener("ml-keyboardmodewillchange", listener as any)
     }
 
     // -- Events
@@ -146,10 +140,6 @@ export class ScreenKeyboard {
         return value
     }
     private onCompositionEnd() {
-        this.debug("compositionend", {
-            valueLength: this.fakeElement.value.length,
-            activeElement: describeElement(document.activeElement)
-        })
         const text = this.extractInsertedText()
         if (text) {
             this.dispatchTextWithLineBreaks(text)
@@ -161,13 +151,6 @@ export class ScreenKeyboard {
         if (!(event instanceof InputEvent)) {
             return
         }
-        this.debug("input", {
-            inputType: event.inputType,
-            data: event.data,
-            isComposing: event.isComposing,
-            valueLength: this.fakeElement.value.length,
-            activeElement: describeElement(document.activeElement)
-        })
         if (event.isComposing) {
             return
         }
@@ -190,21 +173,4 @@ export class ScreenKeyboard {
         // Repopulate the input so that the deleteContent commands will work
         this.resetInputValue()
     }
-
-    private debug(label: string, data?: unknown) {
-        const event: KeyboardDebugEvent = new CustomEvent("ml-keyboarddebug", {
-            detail: { label, data }
-        })
-        this.eventTarget.dispatchEvent(event)
-    }
-}
-
-function describeElement(element: Element | null): string {
-    if (!element) {
-        return "null"
-    }
-
-    const id = element.id ? `#${element.id}` : ""
-    const className = element instanceof HTMLElement && element.className ? `.${element.className}` : ""
-    return `${element.tagName}${id}${className}`
 }

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -9,7 +9,7 @@ import { defaultStreamInputConfig, MouseMode, ScreenKeyboardSetVisibleEvent, Str
 import { getLocalStreamSettings, Settings } from "./component/settings_menu.js";
 import { SelectComponent } from "./component/input.js";
 import { DetailedRole, LogMessageType, StreamCapabilities, StreamKeys, StreamPermissions } from "./api_bindings.js";
-import { KeyboardDebugEvent, KeyboardModeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
+import { KeyboardModeEvent, KeyboardModeWillChangeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
 import { FormModal } from "./component/modal/form.js";
 import { streamStatsToText } from "./stream/stats.js";
 import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations } from "./i18n.js";
@@ -95,8 +95,6 @@ class ViewerApp implements Component {
     private manualFullscreenExitRequested: boolean = false
     private toggleFullscreenWithKeybind: boolean = false
     private hasShownFullscreenEscapeWarning = false
-    private keyboardViewportDebugLog: string[] = []
-    private lastKeyboardViewportDebugLogByLabel = new Map<string, number>()
     private keyboardViewportBaselineHeight: number | null = null
     private streamVideoTopOffsetPx: number = 0
 
@@ -164,7 +162,6 @@ class ViewerApp implements Component {
 
         document.addEventListener("pointerlockchange", this.onPointerLockChange.bind(this))
         document.addEventListener("fullscreenchange", this.onFullscreenChange.bind(this))
-        this.addKeyboardViewportDebugListeners()
 
         window.addEventListener("gamepadconnected", this.onGamepadConnect.bind(this))
         window.addEventListener("gamepaddisconnected", this.onGamepadDisconnect.bind(this))
@@ -287,7 +284,6 @@ class ViewerApp implements Component {
     }
     private onScreenKeyboardSetVisible(event: ScreenKeyboardSetVisibleEvent) {
         console.info(event.detail)
-        this.logKeyboardViewportDebug("screenKeyboardSetVisible", event.detail)
         const screenKeyboard = this.sidebar.getScreenKeyboard()
 
         const newShown = event.detail.visible
@@ -421,7 +417,6 @@ class ViewerApp implements Component {
 
     // Touch
     onTouchStart(event: TouchEvent) {
-        this.logKeyboardViewportDebug("touchstart", touchDebugData(event))
         if (this.beginAutoFullscreenTouchGesture()) {
             event.preventDefault()
             event.stopPropagation()
@@ -436,7 +431,6 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchEnd(event: TouchEvent) {
-        this.logKeyboardViewportDebug("touchend", touchDebugData(event))
         if (this.consumeAutoFullscreenTouchGesture()) {
             event.preventDefault()
             event.stopPropagation()
@@ -451,7 +445,6 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchCancel(event: TouchEvent) {
-        this.logKeyboardViewportDebug("touchcancel", touchDebugData(event))
         if (this.pendingAutoFullscreenTouchGesture) {
             this.pendingAutoFullscreenTouchGesture = false
             event.preventDefault()
@@ -472,12 +465,10 @@ class ViewerApp implements Component {
         this.stream.getInput().onTouchUpdate(this.getStreamRect())
         this.updateKeyboardViewportVideoOffset()
         this.renderLocalTouchCursor()
-        this.logCursorKeyboardViewportDebug("cursorTick")
 
         window.requestAnimationFrame(this.onTouchUpdate.bind(this))
     }
     onTouchMove(event: TouchEvent) {
-        this.logThrottledKeyboardViewportDebug("touchmove", touchDebugData(event), 120)
         if (this.pendingAutoFullscreenTouchGesture) {
             event.preventDefault()
             event.stopPropagation()
@@ -684,55 +675,19 @@ class ViewerApp implements Component {
         this.localTouchCursorDiv.style.top = `${rect.top + localCursorState.y * rect.height}px`
     }
 
-    onScreenKeyboardDebug(event: KeyboardDebugEvent) {
-        if (event.detail.label == "show") {
+    onScreenKeyboardModeWillChange(event: KeyboardModeWillChangeEvent) {
+        if (event.detail.enabled) {
             this.captureKeyboardViewportBaseline()
-        } else if (event.detail.label == "hide") {
-            this.resetKeyboardViewportVideoOffset()
-        }
-
-        this.logKeyboardViewportDebug(`screenKeyboard:${event.detail.label}`, event.detail.data)
-    }
-    async copyKeyboardViewportDebugLog(reason: string) {
-        this.logKeyboardViewportDebug("copyRequested", { reason })
-
-        const text = this.keyboardViewportDebugLog.join("\n")
-        try {
-            await copyTextToClipboard(text)
-            console.info(`Copied keyboard viewport debug log (${this.keyboardViewportDebugLog.length} entries)`)
-        } catch (error) {
-            console.warn("Failed to copy keyboard viewport debug log", error)
         }
     }
-    private addKeyboardViewportDebugListeners() {
-        window.addEventListener("resize", () => this.logKeyboardViewportDebug("window.resize"))
-        window.addEventListener("scroll", () => this.logKeyboardViewportDebug("window.scroll"), { passive: true })
 
-        if (window.visualViewport) {
-            window.visualViewport.addEventListener("resize", () => this.logKeyboardViewportDebug("visualViewport.resize"))
-            window.visualViewport.addEventListener("scroll", () => this.logKeyboardViewportDebug("visualViewport.scroll"))
-        }
-
-        const virtualKeyboard = (navigator as any).virtualKeyboard
-        if (virtualKeyboard?.addEventListener) {
-            virtualKeyboard.addEventListener("geometrychange", () => this.logKeyboardViewportDebug("virtualKeyboard.geometrychange"))
-        }
-
-        this.logKeyboardViewportDebug("debugListenersInstalled", {
-            hasVisualViewport: !!window.visualViewport,
-            hasVirtualKeyboard: !!virtualKeyboard,
-        })
-    }
     private captureKeyboardViewportBaseline() {
         this.keyboardViewportBaselineHeight = window.visualViewport?.height ?? null
         this.streamVideoTopOffsetPx = 0
         this.applyStreamVideoTopOffset()
         this.updateKeyboardFloatingButtonPosition()
-        this.logKeyboardViewportDebug("keyboardViewportBaseline", {
-            height: this.keyboardViewportBaselineHeight,
-        })
     }
-    private resetKeyboardViewportVideoOffset() {
+    resetKeyboardViewportVideoOffset() {
         this.keyboardViewportBaselineHeight = null
         this.streamVideoTopOffsetPx = 0
         this.applyStreamVideoTopOffset()
@@ -758,7 +713,6 @@ class ViewerApp implements Component {
             if (this.streamVideoTopOffsetPx != 0) {
                 this.streamVideoTopOffsetPx = 0
                 this.applyStreamVideoTopOffset()
-                this.logKeyboardViewportDebug("streamVideoOffsetReset", { reason: "viewport-not-shrunk" })
             }
             return
         }
@@ -786,15 +740,6 @@ class ViewerApp implements Component {
 
         this.streamVideoTopOffsetPx += delta
         this.applyStreamVideoTopOffset()
-        this.logKeyboardViewportDebug("streamVideoOffsetAdjusted", {
-            delta,
-            offset: this.streamVideoTopOffsetPx,
-            cursorY,
-            visibleTop,
-            visibleBottom,
-            safeMargin,
-            viewportShrink,
-        })
     }
     private applyStreamVideoTopOffset() {
         if (Math.abs(this.streamVideoTopOffsetPx) < 0.5) {
@@ -818,65 +763,6 @@ class ViewerApp implements Component {
     }
     private resetKeyboardFloatingButtonPosition() {
         document.documentElement.style.removeProperty("--stream-keyboard-button-top")
-    }
-    private logCursorKeyboardViewportDebug(label: string) {
-        if (!this.shouldLogThrottled(label, 250)) {
-            return
-        }
-        this.logKeyboardViewportDebug(label)
-    }
-    private logThrottledKeyboardViewportDebug(label: string, extra: unknown, intervalMs: number) {
-        if (!this.shouldLogThrottled(label, intervalMs)) {
-            return
-        }
-
-        this.logKeyboardViewportDebug(label, extra)
-    }
-    private shouldLogThrottled(label: string, intervalMs: number): boolean {
-        const now = performance.now()
-        const last = this.lastKeyboardViewportDebugLogByLabel.get(label) ?? 0
-        if (now - last < intervalMs) {
-            return false
-        }
-
-        this.lastKeyboardViewportDebugLogByLabel.set(label, now)
-        return true
-    }
-    private logKeyboardViewportDebug(label: string, extra?: unknown) {
-        const entry = {
-            time: new Date().toISOString(),
-            label,
-            extra,
-            viewport: getViewportDebugSnapshot(),
-            fullscreen: this.isFullscreen(),
-            pointerLock: !!document.pointerLockElement,
-            activeElement: describeElement(document.activeElement),
-            keyboardModeEnabled: this.sidebar.getScreenKeyboard().isVisible(),
-            touchAction: this.stream.getInput().getCurrentPredictedTouchAction(),
-            streamRect: rectDebugData(this.getStreamRect()),
-            localCursor: this.getLocalCursorDebugData(),
-        }
-
-        this.keyboardViewportDebugLog.push(JSON.stringify(entry))
-        if (this.keyboardViewportDebugLog.length > 1200) {
-            this.keyboardViewportDebugLog.splice(0, this.keyboardViewportDebugLog.length - 1200)
-        }
-    }
-    private getLocalCursorDebugData() {
-        const localCursorState = this.stream.getInput().getLocalCursorState()
-        const rect = this.getStreamRect()
-        const screenX = localCursorState ? rect.left + localCursorState.x * rect.width : null
-        const screenY = localCursorState ? rect.top + localCursorState.y * rect.height : null
-        const visibleRect = getVisibleViewportRect()
-        const virtualKeyboardRect = getVirtualKeyboardRect()
-
-        return {
-            state: localCursorState,
-            screenX,
-            screenY,
-            coveredByVisibleViewport: screenX == null || screenY == null ? null : !pointInRect(screenX, screenY, visibleRect),
-            coveredByVirtualKeyboard: screenX == null || screenY == null || !virtualKeyboardRect ? null : pointInRect(screenX, screenY, virtualKeyboardRect),
-        }
     }
 
     mount(parent: HTMLElement): void {
@@ -1121,8 +1007,8 @@ class ViewerSidebar implements Component, Sidebar {
         this.screenKeyboard.addKeyDownListener(this.onKeyDown.bind(this))
         this.screenKeyboard.addKeyUpListener(this.onKeyUp.bind(this))
         this.screenKeyboard.addTextListener(this.onText.bind(this))
+        this.screenKeyboard.addKeyboardModeWillChangeListener(this.app.onScreenKeyboardModeWillChange.bind(this.app))
         this.screenKeyboard.addKeyboardModeListener(this.onKeyboardModeChange.bind(this))
-        this.screenKeyboard.addDebugListener(this.app.onScreenKeyboardDebug.bind(this.app))
         this.div.appendChild(this.screenKeyboard.getHiddenElement())
 
 
@@ -1151,7 +1037,6 @@ class ViewerSidebar implements Component, Sidebar {
         // Close stream
         this.exitStreamButton.innerText = I.stream.exit
         this.exitStreamButton.addEventListener("click", async () => {
-            await this.app.copyKeyboardViewportDebugLog("exitStreamButton")
             const stream = this.app.getStream()
             if (stream) {
                 const success = await stream.stop()
@@ -1219,6 +1104,7 @@ class ViewerSidebar implements Component, Sidebar {
             this.floatingKeyboardButton.classList.add("visible")
         } else {
             this.floatingKeyboardButton.classList.remove("visible")
+            this.app.resetKeyboardViewportVideoOffset()
         }
     }
 
@@ -1324,150 +1210,4 @@ function stopPropagationOn(element: HTMLElement) {
 }
 function onStopPropagation(event: Event) {
     event.stopPropagation()
-}
-
-function getViewportDebugSnapshot() {
-    const visualViewport = window.visualViewport
-    const virtualKeyboardRect = getVirtualKeyboardRect()
-
-    return {
-        window: {
-            innerWidth: window.innerWidth,
-            innerHeight: window.innerHeight,
-            outerWidth: window.outerWidth,
-            outerHeight: window.outerHeight,
-            scrollX: window.scrollX,
-            scrollY: window.scrollY,
-        },
-        documentElement: {
-            clientWidth: document.documentElement.clientWidth,
-            clientHeight: document.documentElement.clientHeight,
-            scrollWidth: document.documentElement.scrollWidth,
-            scrollHeight: document.documentElement.scrollHeight,
-            scrollTop: document.documentElement.scrollTop,
-            scrollLeft: document.documentElement.scrollLeft,
-        },
-        body: {
-            clientWidth: document.body?.clientWidth,
-            clientHeight: document.body?.clientHeight,
-            scrollWidth: document.body?.scrollWidth,
-            scrollHeight: document.body?.scrollHeight,
-            scrollTop: document.body?.scrollTop,
-            scrollLeft: document.body?.scrollLeft,
-        },
-        visualViewport: visualViewport ? {
-            width: visualViewport.width,
-            height: visualViewport.height,
-            offsetLeft: visualViewport.offsetLeft,
-            offsetTop: visualViewport.offsetTop,
-            pageLeft: visualViewport.pageLeft,
-            pageTop: visualViewport.pageTop,
-            scale: visualViewport.scale,
-        } : null,
-        virtualKeyboard: {
-            supported: !!(navigator as any).virtualKeyboard,
-            boundingRect: virtualKeyboardRect,
-        },
-        screen: {
-            width: screen.width,
-            height: screen.height,
-            availWidth: screen.availWidth,
-            availHeight: screen.availHeight,
-            orientation: screen.orientation ? {
-                type: screen.orientation.type,
-                angle: screen.orientation.angle,
-            } : null,
-        },
-    }
-}
-
-function getVisibleViewportRect(): DOMRectReadOnly {
-    const visualViewport = window.visualViewport
-    if (!visualViewport) {
-        return new DOMRect(0, 0, window.innerWidth, window.innerHeight)
-    }
-
-    return new DOMRect(
-        visualViewport.offsetLeft,
-        visualViewport.offsetTop,
-        visualViewport.width,
-        visualViewport.height
-    )
-}
-
-function getVirtualKeyboardRect(): { x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number } | null {
-    const rect = (navigator as any).virtualKeyboard?.boundingRect
-    if (!rect) {
-        return null
-    }
-
-    return rectDebugData(rect)
-}
-
-function rectDebugData(rect: DOMRectReadOnly): { x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number } {
-    return {
-        x: rect.x,
-        y: rect.y,
-        width: rect.width,
-        height: rect.height,
-        top: rect.top,
-        right: rect.right,
-        bottom: rect.bottom,
-        left: rect.left,
-    }
-}
-
-function pointInRect(x: number, y: number, rect: DOMRectReadOnly | { top: number, right: number, bottom: number, left: number }): boolean {
-    return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
-}
-
-function touchDebugData(event: TouchEvent) {
-    return {
-        touches: Array.from(event.touches).map(touchPointDebugData),
-        changedTouches: Array.from(event.changedTouches).map(touchPointDebugData),
-        target: event.target instanceof Element ? describeElement(event.target) : String(event.target),
-    }
-}
-
-function touchPointDebugData(touch: Touch) {
-    return {
-        identifier: touch.identifier,
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        pageX: touch.pageX,
-        pageY: touch.pageY,
-        screenX: touch.screenX,
-        screenY: touch.screenY,
-    }
-}
-
-function describeElement(element: Element | null): string {
-    if (!element) {
-        return "null"
-    }
-
-    const id = element.id ? `#${element.id}` : ""
-    const className = element instanceof HTMLElement && element.className ? `.${element.className}` : ""
-    return `${element.tagName}${id}${className}`
-}
-
-async function copyTextToClipboard(text: string) {
-    if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text)
-        return
-    }
-
-    const textarea = document.createElement("textarea")
-    textarea.value = text
-    textarea.style.position = "fixed"
-    textarea.style.left = "-9999px"
-    textarea.style.top = "-9999px"
-    document.body.appendChild(textarea)
-    textarea.focus()
-    textarea.select()
-    try {
-        document.execCommand("copy")
-    } finally {
-        document.body.removeChild(textarea)
-    }
 }

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -9,7 +9,7 @@ import { defaultStreamInputConfig, MouseMode, ScreenKeyboardSetVisibleEvent, Str
 import { getLocalStreamSettings, Settings } from "./component/settings_menu.js";
 import { SelectComponent } from "./component/input.js";
 import { DetailedRole, LogMessageType, StreamCapabilities, StreamKeys, StreamPermissions } from "./api_bindings.js";
-import { KeyboardModeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
+import { KeyboardDebugEvent, KeyboardModeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
 import { FormModal } from "./component/modal/form.js";
 import { streamStatsToText } from "./stream/stats.js";
 import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations } from "./i18n.js";
@@ -95,6 +95,10 @@ class ViewerApp implements Component {
     private manualFullscreenExitRequested: boolean = false
     private toggleFullscreenWithKeybind: boolean = false
     private hasShownFullscreenEscapeWarning = false
+    private keyboardViewportDebugLog: string[] = []
+    private lastKeyboardViewportDebugLogByLabel = new Map<string, number>()
+    private keyboardViewportBaselineHeight: number | null = null
+    private streamVideoTopOffsetPx: number = 0
 
     constructor(api: Api, hostId: number, appId: number, bootstrapRole: DetailedRole) {
         this.api = api
@@ -160,6 +164,7 @@ class ViewerApp implements Component {
 
         document.addEventListener("pointerlockchange", this.onPointerLockChange.bind(this))
         document.addEventListener("fullscreenchange", this.onFullscreenChange.bind(this))
+        this.addKeyboardViewportDebugListeners()
 
         window.addEventListener("gamepadconnected", this.onGamepadConnect.bind(this))
         window.addEventListener("gamepaddisconnected", this.onGamepadDisconnect.bind(this))
@@ -282,6 +287,7 @@ class ViewerApp implements Component {
     }
     private onScreenKeyboardSetVisible(event: ScreenKeyboardSetVisibleEvent) {
         console.info(event.detail)
+        this.logKeyboardViewportDebug("screenKeyboardSetVisible", event.detail)
         const screenKeyboard = this.sidebar.getScreenKeyboard()
 
         const newShown = event.detail.visible
@@ -415,6 +421,7 @@ class ViewerApp implements Component {
 
     // Touch
     onTouchStart(event: TouchEvent) {
+        this.logKeyboardViewportDebug("touchstart", touchDebugData(event))
         if (this.beginAutoFullscreenTouchGesture()) {
             event.preventDefault()
             event.stopPropagation()
@@ -429,6 +436,7 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchEnd(event: TouchEvent) {
+        this.logKeyboardViewportDebug("touchend", touchDebugData(event))
         if (this.consumeAutoFullscreenTouchGesture()) {
             event.preventDefault()
             event.stopPropagation()
@@ -443,6 +451,7 @@ class ViewerApp implements Component {
         event.stopPropagation()
     }
     onTouchCancel(event: TouchEvent) {
+        this.logKeyboardViewportDebug("touchcancel", touchDebugData(event))
         if (this.pendingAutoFullscreenTouchGesture) {
             this.pendingAutoFullscreenTouchGesture = false
             event.preventDefault()
@@ -461,11 +470,14 @@ class ViewerApp implements Component {
     }
     onTouchUpdate() {
         this.stream.getInput().onTouchUpdate(this.getStreamRect())
+        this.updateKeyboardViewportVideoOffset()
         this.renderLocalTouchCursor()
+        this.logCursorKeyboardViewportDebug("cursorTick")
 
         window.requestAnimationFrame(this.onTouchUpdate.bind(this))
     }
     onTouchMove(event: TouchEvent) {
+        this.logThrottledKeyboardViewportDebug("touchmove", touchDebugData(event), 120)
         if (this.pendingAutoFullscreenTouchGesture) {
             event.preventDefault()
             event.stopPropagation()
@@ -670,6 +682,201 @@ class ViewerApp implements Component {
         this.localTouchCursorDiv.hidden = false
         this.localTouchCursorDiv.style.left = `${rect.left + localCursorState.x * rect.width}px`
         this.localTouchCursorDiv.style.top = `${rect.top + localCursorState.y * rect.height}px`
+    }
+
+    onScreenKeyboardDebug(event: KeyboardDebugEvent) {
+        if (event.detail.label == "show") {
+            this.captureKeyboardViewportBaseline()
+        } else if (event.detail.label == "hide") {
+            this.resetKeyboardViewportVideoOffset()
+        }
+
+        this.logKeyboardViewportDebug(`screenKeyboard:${event.detail.label}`, event.detail.data)
+    }
+    async copyKeyboardViewportDebugLog(reason: string) {
+        this.logKeyboardViewportDebug("copyRequested", { reason })
+
+        const text = this.keyboardViewportDebugLog.join("\n")
+        try {
+            await copyTextToClipboard(text)
+            console.info(`Copied keyboard viewport debug log (${this.keyboardViewportDebugLog.length} entries)`)
+        } catch (error) {
+            console.warn("Failed to copy keyboard viewport debug log", error)
+        }
+    }
+    private addKeyboardViewportDebugListeners() {
+        window.addEventListener("resize", () => this.logKeyboardViewportDebug("window.resize"))
+        window.addEventListener("scroll", () => this.logKeyboardViewportDebug("window.scroll"), { passive: true })
+
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener("resize", () => this.logKeyboardViewportDebug("visualViewport.resize"))
+            window.visualViewport.addEventListener("scroll", () => this.logKeyboardViewportDebug("visualViewport.scroll"))
+        }
+
+        const virtualKeyboard = (navigator as any).virtualKeyboard
+        if (virtualKeyboard?.addEventListener) {
+            virtualKeyboard.addEventListener("geometrychange", () => this.logKeyboardViewportDebug("virtualKeyboard.geometrychange"))
+        }
+
+        this.logKeyboardViewportDebug("debugListenersInstalled", {
+            hasVisualViewport: !!window.visualViewport,
+            hasVirtualKeyboard: !!virtualKeyboard,
+        })
+    }
+    private captureKeyboardViewportBaseline() {
+        this.keyboardViewportBaselineHeight = window.visualViewport?.height ?? null
+        this.streamVideoTopOffsetPx = 0
+        this.applyStreamVideoTopOffset()
+        this.updateKeyboardFloatingButtonPosition()
+        this.logKeyboardViewportDebug("keyboardViewportBaseline", {
+            height: this.keyboardViewportBaselineHeight,
+        })
+    }
+    private resetKeyboardViewportVideoOffset() {
+        this.keyboardViewportBaselineHeight = null
+        this.streamVideoTopOffsetPx = 0
+        this.applyStreamVideoTopOffset()
+        this.resetKeyboardFloatingButtonPosition()
+    }
+    private updateKeyboardViewportVideoOffset() {
+        this.updateKeyboardFloatingButtonPosition()
+
+        const screenKeyboard = this.sidebar.getScreenKeyboard()
+        const visualViewport = window.visualViewport
+        const baselineHeight = this.keyboardViewportBaselineHeight
+        const localCursorState = this.stream.getInput().getLocalCursorState()
+
+        if (!screenKeyboard.isVisible() || !visualViewport || baselineHeight == null || !localCursorState?.visible) {
+            if (this.streamVideoTopOffsetPx != 0 && !screenKeyboard.isVisible()) {
+                this.resetKeyboardViewportVideoOffset()
+            }
+            return
+        }
+
+        const viewportShrink = baselineHeight - visualViewport.height
+        if (viewportShrink < 80) {
+            if (this.streamVideoTopOffsetPx != 0) {
+                this.streamVideoTopOffsetPx = 0
+                this.applyStreamVideoTopOffset()
+                this.logKeyboardViewportDebug("streamVideoOffsetReset", { reason: "viewport-not-shrunk" })
+            }
+            return
+        }
+
+        const streamRect = this.getStreamRect()
+        if (streamRect.width <= 0 || streamRect.height <= 0) {
+            return
+        }
+
+        const visibleTop = visualViewport.offsetTop
+        const visibleBottom = visualViewport.offsetTop + visualViewport.height
+        const safeMargin = Math.min(100, visualViewport.height * 0.25)
+        const cursorY = streamRect.top + localCursorState.y * streamRect.height
+
+        let delta = 0
+        if (cursorY < visibleTop + safeMargin) {
+            delta = visibleTop + safeMargin - cursorY
+        } else if (cursorY > visibleBottom - safeMargin) {
+            delta = visibleBottom - safeMargin - cursorY
+        }
+
+        if (Math.abs(delta) < 1) {
+            return
+        }
+
+        this.streamVideoTopOffsetPx += delta
+        this.applyStreamVideoTopOffset()
+        this.logKeyboardViewportDebug("streamVideoOffsetAdjusted", {
+            delta,
+            offset: this.streamVideoTopOffsetPx,
+            cursorY,
+            visibleTop,
+            visibleBottom,
+            safeMargin,
+            viewportShrink,
+        })
+    }
+    private applyStreamVideoTopOffset() {
+        if (Math.abs(this.streamVideoTopOffsetPx) < 0.5) {
+            document.documentElement.style.removeProperty("--stream-video-top")
+            return
+        }
+
+        document.documentElement.style.setProperty("--stream-video-top", `calc(50% + ${this.streamVideoTopOffsetPx}px)`)
+    }
+    private updateKeyboardFloatingButtonPosition() {
+        const screenKeyboard = this.sidebar.getScreenKeyboard()
+        const visualViewport = window.visualViewport
+        if (!screenKeyboard.isVisible() || !visualViewport) {
+            this.resetKeyboardFloatingButtonPosition()
+            return
+        }
+
+        const bottomInset = Math.min(16, visualViewport.height * 0.08)
+        const buttonTop = visualViewport.offsetTop + visualViewport.height - bottomInset
+        document.documentElement.style.setProperty("--stream-keyboard-button-top", `${buttonTop}px`)
+    }
+    private resetKeyboardFloatingButtonPosition() {
+        document.documentElement.style.removeProperty("--stream-keyboard-button-top")
+    }
+    private logCursorKeyboardViewportDebug(label: string) {
+        if (!this.shouldLogThrottled(label, 250)) {
+            return
+        }
+        this.logKeyboardViewportDebug(label)
+    }
+    private logThrottledKeyboardViewportDebug(label: string, extra: unknown, intervalMs: number) {
+        if (!this.shouldLogThrottled(label, intervalMs)) {
+            return
+        }
+
+        this.logKeyboardViewportDebug(label, extra)
+    }
+    private shouldLogThrottled(label: string, intervalMs: number): boolean {
+        const now = performance.now()
+        const last = this.lastKeyboardViewportDebugLogByLabel.get(label) ?? 0
+        if (now - last < intervalMs) {
+            return false
+        }
+
+        this.lastKeyboardViewportDebugLogByLabel.set(label, now)
+        return true
+    }
+    private logKeyboardViewportDebug(label: string, extra?: unknown) {
+        const entry = {
+            time: new Date().toISOString(),
+            label,
+            extra,
+            viewport: getViewportDebugSnapshot(),
+            fullscreen: this.isFullscreen(),
+            pointerLock: !!document.pointerLockElement,
+            activeElement: describeElement(document.activeElement),
+            keyboardModeEnabled: this.sidebar.getScreenKeyboard().isVisible(),
+            touchAction: this.stream.getInput().getCurrentPredictedTouchAction(),
+            streamRect: rectDebugData(this.getStreamRect()),
+            localCursor: this.getLocalCursorDebugData(),
+        }
+
+        this.keyboardViewportDebugLog.push(JSON.stringify(entry))
+        if (this.keyboardViewportDebugLog.length > 1200) {
+            this.keyboardViewportDebugLog.splice(0, this.keyboardViewportDebugLog.length - 1200)
+        }
+    }
+    private getLocalCursorDebugData() {
+        const localCursorState = this.stream.getInput().getLocalCursorState()
+        const rect = this.getStreamRect()
+        const screenX = localCursorState ? rect.left + localCursorState.x * rect.width : null
+        const screenY = localCursorState ? rect.top + localCursorState.y * rect.height : null
+        const visibleRect = getVisibleViewportRect()
+        const virtualKeyboardRect = getVirtualKeyboardRect()
+
+        return {
+            state: localCursorState,
+            screenX,
+            screenY,
+            coveredByVisibleViewport: screenX == null || screenY == null ? null : !pointInRect(screenX, screenY, visibleRect),
+            coveredByVirtualKeyboard: screenX == null || screenY == null || !virtualKeyboardRect ? null : pointInRect(screenX, screenY, virtualKeyboardRect),
+        }
     }
 
     mount(parent: HTMLElement): void {
@@ -915,6 +1122,7 @@ class ViewerSidebar implements Component, Sidebar {
         this.screenKeyboard.addKeyUpListener(this.onKeyUp.bind(this))
         this.screenKeyboard.addTextListener(this.onText.bind(this))
         this.screenKeyboard.addKeyboardModeListener(this.onKeyboardModeChange.bind(this))
+        this.screenKeyboard.addDebugListener(this.app.onScreenKeyboardDebug.bind(this.app))
         this.div.appendChild(this.screenKeyboard.getHiddenElement())
 
 
@@ -943,6 +1151,7 @@ class ViewerSidebar implements Component, Sidebar {
         // Close stream
         this.exitStreamButton.innerText = I.stream.exit
         this.exitStreamButton.addEventListener("click", async () => {
+            await this.app.copyKeyboardViewportDebugLog("exitStreamButton")
             const stream = this.app.getStream()
             if (stream) {
                 const success = await stream.stop()
@@ -1115,4 +1324,150 @@ function stopPropagationOn(element: HTMLElement) {
 }
 function onStopPropagation(event: Event) {
     event.stopPropagation()
+}
+
+function getViewportDebugSnapshot() {
+    const visualViewport = window.visualViewport
+    const virtualKeyboardRect = getVirtualKeyboardRect()
+
+    return {
+        window: {
+            innerWidth: window.innerWidth,
+            innerHeight: window.innerHeight,
+            outerWidth: window.outerWidth,
+            outerHeight: window.outerHeight,
+            scrollX: window.scrollX,
+            scrollY: window.scrollY,
+        },
+        documentElement: {
+            clientWidth: document.documentElement.clientWidth,
+            clientHeight: document.documentElement.clientHeight,
+            scrollWidth: document.documentElement.scrollWidth,
+            scrollHeight: document.documentElement.scrollHeight,
+            scrollTop: document.documentElement.scrollTop,
+            scrollLeft: document.documentElement.scrollLeft,
+        },
+        body: {
+            clientWidth: document.body?.clientWidth,
+            clientHeight: document.body?.clientHeight,
+            scrollWidth: document.body?.scrollWidth,
+            scrollHeight: document.body?.scrollHeight,
+            scrollTop: document.body?.scrollTop,
+            scrollLeft: document.body?.scrollLeft,
+        },
+        visualViewport: visualViewport ? {
+            width: visualViewport.width,
+            height: visualViewport.height,
+            offsetLeft: visualViewport.offsetLeft,
+            offsetTop: visualViewport.offsetTop,
+            pageLeft: visualViewport.pageLeft,
+            pageTop: visualViewport.pageTop,
+            scale: visualViewport.scale,
+        } : null,
+        virtualKeyboard: {
+            supported: !!(navigator as any).virtualKeyboard,
+            boundingRect: virtualKeyboardRect,
+        },
+        screen: {
+            width: screen.width,
+            height: screen.height,
+            availWidth: screen.availWidth,
+            availHeight: screen.availHeight,
+            orientation: screen.orientation ? {
+                type: screen.orientation.type,
+                angle: screen.orientation.angle,
+            } : null,
+        },
+    }
+}
+
+function getVisibleViewportRect(): DOMRectReadOnly {
+    const visualViewport = window.visualViewport
+    if (!visualViewport) {
+        return new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+    }
+
+    return new DOMRect(
+        visualViewport.offsetLeft,
+        visualViewport.offsetTop,
+        visualViewport.width,
+        visualViewport.height
+    )
+}
+
+function getVirtualKeyboardRect(): { x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number } | null {
+    const rect = (navigator as any).virtualKeyboard?.boundingRect
+    if (!rect) {
+        return null
+    }
+
+    return rectDebugData(rect)
+}
+
+function rectDebugData(rect: DOMRectReadOnly): { x: number, y: number, width: number, height: number, top: number, right: number, bottom: number, left: number } {
+    return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+    }
+}
+
+function pointInRect(x: number, y: number, rect: DOMRectReadOnly | { top: number, right: number, bottom: number, left: number }): boolean {
+    return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+}
+
+function touchDebugData(event: TouchEvent) {
+    return {
+        touches: Array.from(event.touches).map(touchPointDebugData),
+        changedTouches: Array.from(event.changedTouches).map(touchPointDebugData),
+        target: event.target instanceof Element ? describeElement(event.target) : String(event.target),
+    }
+}
+
+function touchPointDebugData(touch: Touch) {
+    return {
+        identifier: touch.identifier,
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+        pageX: touch.pageX,
+        pageY: touch.pageY,
+        screenX: touch.screenX,
+        screenY: touch.screenY,
+    }
+}
+
+function describeElement(element: Element | null): string {
+    if (!element) {
+        return "null"
+    }
+
+    const id = element.id ? `#${element.id}` : ""
+    const className = element instanceof HTMLElement && element.className ? `.${element.className}` : ""
+    return `${element.tagName}${id}${className}`
+}
+
+async function copyTextToClipboard(text: string) {
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+        return
+    }
+
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.style.position = "fixed"
+    textarea.style.left = "-9999px"
+    textarea.style.top = "-9999px"
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    try {
+        document.execCommand("copy")
+    } finally {
+        document.body.removeChild(textarea)
+    }
 }

--- a/web/styles/moonlight.css
+++ b/web/styles/moonlight.css
@@ -821,7 +821,7 @@ input[type=number] {
 /** Stream */
 .video-stream {
     position: fixed;
-    top: 50%;
+    top: var(--stream-video-top, 50%);
     left: 50%;
     transform: translate(-50%, -50%);
     max-width: 100vw;
@@ -884,9 +884,9 @@ canvas.video-stream {
 
 .stream-keyboard-floating-button {
     position: fixed;
-    top: 50%;
+    top: var(--stream-keyboard-button-top, 50%);
     right: 12px;
-    transform: translateY(-50%);
+    transform: translateY(-100%);
     width: 44px;
     height: 44px;
     z-index: 1000;
@@ -911,7 +911,7 @@ canvas.video-stream {
 
 .stream-keyboard-floating-button:active {
     opacity: 1;
-    transform: translateY(-50%) scale(0.95);
+    transform: translateY(-100%) scale(0.95);
 }
 
 /* Prevent starting animation for elements */

--- a/web/styles/standard.css
+++ b/web/styles/standard.css
@@ -1215,7 +1215,7 @@ input[type=number] {
 /** Stream */
 .video-stream {
     position: fixed;
-    top: 50%;
+    top: var(--stream-video-top, 50%);
     left: 50%;
     transform: translate(-50%, -50%);
     max-width: 100vw;
@@ -1279,9 +1279,9 @@ canvas.video-stream {
 
 .stream-keyboard-floating-button {
     position: fixed;
-    top: 50%;
+    top: var(--stream-keyboard-button-top, 50%);
     right: 12px;
-    transform: translateY(-50%);
+    transform: translateY(-100%);
     width: 44px;
     height: 44px;
     z-index: 1000;
@@ -1306,7 +1306,7 @@ canvas.video-stream {
 
 .stream-keyboard-floating-button:active {
     opacity: 1;
-    transform: translateY(-50%) scale(0.95);
+    transform: translateY(-100%) scale(0.95);
 }
 
 /* Prevent starting animation for elements */


### PR DESCRIPTION
## Summary

This is a draft / prototype PR for the next step after #137.

The goal is to keep the local cursor usable while the mobile soft keyboard is open. Instead of trying to know the exact keyboard height, this prototype uses `visualViewport` as the source of the currently visible area:

- Capture the `visualViewport.height` baseline when keyboard mode is opened.
- If the visible viewport height shrinks significantly, treat it as a normal soft keyboard affecting the visible area.
- Keep the local cursor away from the top/bottom edge of the visible viewport by shifting the displayed stream vertically.
- Use a dynamic safe margin: `min(100px, visualViewport.height * 0.25)` so very small visible areas do not fight the adjustment.
- Move the floating keyboard close button to the bottom of the current visible viewport so it is not covered by the keyboard.

## Important draft notes

This PR intentionally still contains debug instrumentation:

- viewport / visualViewport / scroll / cursor state logging
- screen keyboard debug events
- copying the debug log to the clipboard when exiting the stream

I am leaving this in the draft on purpose so the behavior can be inspected and discussed before cleanup. If the direction looks good, I can split/clean it into a normal PR with the debug code removed.

## Current behavior tested

On my device this prototype works well for:

- non-fullscreen normal soft keyboard, where the browser both shrinks `visualViewport.height` and shifts/scrolls the page
- fullscreen normal soft keyboard, where `visualViewport.height` shrinks while window/document sizes and scroll stay unchanged
- floating keyboard is intentionally not handled, because its position is user-controlled and not reliably exposed to the page

## Limitations / questions

- This is a simple implementation and probably not the final structure.
- It currently adjusts the stream display position only; it does not change remote input coordinates.
- It relies on `visualViewport` shrink detection, not `VirtualKeyboard.boundingRect`, because on my device `navigator.virtualKeyboard.boundingRect` stayed `0x0`.
- If this behavior feels right, the next step would be to remove the debug logging and make the viewport-adjustment code cleaner.

## Testing

- Ran `npm run build-light` successfully.
- Deployed to a router-hosted build and tested on a mobile browser.