### PR TITLE
add an option to force WASM opus decoder

### DIFF
--- a/common/src/api_bindings.rs
+++ b/common/src/api_bindings.rs
@@ -304,6 +304,8 @@ pub struct StreamSettings {
     pub height: u32,
     pub fps: u32,
     pub play_audio_local: bool,
+    #[serde(default)]
+    pub use_wasm_opus_decoder: bool,
     /// This is using the [VideoFormats]
     pub supported_codecs: u32,
     pub hdr: bool,

--- a/streamer/src/transport/web_socket/mod.rs
+++ b/streamer/src/transport/web_socket/mod.rs
@@ -164,7 +164,7 @@ impl TransportSender for WebSocketTransportSender {
         &'a self,
         unit: VideoDecodeUnit<&'a [u8]>,
     ) -> Result<DecodeResult, TransportError> {
-        let mut new_buffer = vec![0; 5];
+        let mut new_buffer = vec![0; 6];
 
         let mut byte_buffer = ByteBuffer::new(new_buffer.as_mut_slice());
         byte_buffer.put_u8(TransportChannelId::HOST_VIDEO);
@@ -172,7 +172,6 @@ impl TransportSender for WebSocketTransportSender {
             FrameType::Idr => 1,
             FrameType::PFrame => 0,
         });
-        byte_buffer.put_u8(0);
         byte_buffer.put_u32(unit.timestamp.as_micros() as u32);
 
         for buffer in &unit.buffers {

--- a/streamer/src/transport/webrtc/audio.rs
+++ b/streamer/src/transport/webrtc/audio.rs
@@ -1,4 +1,7 @@
-use std::{sync::Weak, time::Duration};
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use bytes::Bytes;
 use log::{error, warn};
@@ -6,6 +9,7 @@ use moonlight_common::stream::audio::{AudioConfig, OpusMultistreamConfig};
 use tokio::runtime::Handle;
 use webrtc::{
     api::media_engine::{MIME_TYPE_OPUS, MediaEngine},
+    data_channel::{RTCDataChannel, data_channel_init::RTCDataChannelInit},
     media::Sample,
     peer_connection::RTCPeerConnection,
     rtp_transceiver::rtp_codec::{RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType},
@@ -35,6 +39,8 @@ pub fn register_audio_codecs(media_engine: &mut MediaEngine) -> Result<(), webrt
 
 pub struct WebRtcAudio {
     sender: TrackLocalSender<TrackLocalStaticSample>,
+    data_channel: Option<Arc<RTCDataChannel>>,
+    use_data_channel: bool,
     config: Option<OpusMultistreamConfig>,
 }
 
@@ -42,15 +48,21 @@ impl WebRtcAudio {
     pub fn new(runtime: Handle, peer: Weak<RTCPeerConnection>, channel_queue_size: usize) -> Self {
         Self {
             sender: TrackLocalSender::new(runtime, peer, channel_queue_size),
+            data_channel: None,
+            use_data_channel: false,
             config: None,
         }
     }
 }
 
 impl WebRtcAudio {
+    pub fn set_use_data_channel(&mut self, use_data_channel: bool) {
+        self.use_data_channel = use_data_channel;
+    }
+
     pub async fn setup(
         &mut self,
-        _inner: &WebRtcInner,
+        inner: &WebRtcInner,
         audio_config: AudioConfig,
         stream_config: OpusMultistreamConfig,
     ) -> i32 {
@@ -66,6 +78,34 @@ impl WebRtcAudio {
                 "[Stream] A different audio configuration than requested was selected, Expected: {:?}, Found: {audio_config:?}",
                 self.config()
             );
+        }
+
+        if self.use_data_channel {
+            if self.data_channel.is_none() {
+                match inner
+                    .peer
+                    .create_data_channel(
+                        "HOST_AUDIO",
+                        Some(RTCDataChannelInit {
+                            ordered: Some(true),
+                            max_retransmits: Some(0),
+                            ..Default::default()
+                        }),
+                    )
+                    .await
+                {
+                    Ok(channel) => {
+                        self.data_channel = Some(channel);
+                    }
+                    Err(err) => {
+                        error!("Failed to create opus data channel: {err:?}");
+                        return -1;
+                    }
+                }
+            }
+
+            self.config = Some(stream_config);
+            return 0;
         }
 
         if let Err(err) = self
@@ -96,6 +136,17 @@ impl WebRtcAudio {
         let Some(config) = self.config.as_ref() else {
             return;
         };
+
+        if self.use_data_channel {
+            let Some(channel) = self.data_channel.as_ref() else {
+                return;
+            };
+
+            if let Err(err) = channel.send(&Bytes::copy_from_slice(data)).await {
+                warn!("Failed to send opus data channel sample: {err:?}");
+            }
+            return;
+        }
 
         let duration =
             Duration::from_secs_f64(config.samples_per_frame as f64 / config.sample_rate as f64);

--- a/streamer/src/transport/webrtc/mod.rs
+++ b/streamer/src/transport/webrtc/mod.rs
@@ -399,6 +399,10 @@ impl WebRtcInner {
                     let mut video = self.video.lock().await;
                     video.set_codecs(video_supported_formats).await;
                 }
+                {
+                    let mut audio = self.audio.lock().await;
+                    audio.set_use_data_channel(settings.use_wasm_opus_decoder);
+                }
 
                 // TODO: check peer for supported formats via sdp
 

--- a/web/component/settings_menu.ts
+++ b/web/component/settings_menu.ts
@@ -21,6 +21,7 @@ export type Settings = {
     canvasRenderer: boolean
     canvasVsync: boolean
     playAudioLocal: boolean
+    useWasmOpusDecoder: boolean
     audioSampleQueueSize: number
     mouseScrollMode: MouseScrollMode
     mouseMode: MouseMode
@@ -165,6 +166,7 @@ export class StreamSettingsComponent implements Component {
 
     private audioHeader: HTMLHeadingElement = document.createElement("h3")
     private playAudioLocal: InputComponent
+    private useWasmOpusDecoder: InputComponent
     private audioSampleQueueSize: InputComponent
 
     private mouseHeader: HTMLHeadingElement = document.createElement("h3")
@@ -357,6 +359,12 @@ export class StreamSettingsComponent implements Component {
         })
         this.playAudioLocal.addChangeListener(this.onSettingsChange.bind(this))
         this.playAudioLocal.mount(this.divElement)
+
+        this.useWasmOpusDecoder = new InputComponent("useWasmOpusDecoder", "checkbox", i.useWasmOpusDecoder, {
+            checked: settings?.useWasmOpusDecoder ?? defaultSettings_.useWasmOpusDecoder
+        })
+        this.useWasmOpusDecoder.addChangeListener(this.onSettingsChange.bind(this))
+        this.useWasmOpusDecoder.mount(this.divElement)
 
         // Audio Sample Queue Size
         this.audioSampleQueueSize = new InputComponent("audioSampleQueueSize", "number", i.audioSampleQueueSize, {
@@ -568,6 +576,7 @@ export class StreamSettingsComponent implements Component {
         settings.canvasVsync = this.canvasVsync.isChecked()
 
         settings.playAudioLocal = this.playAudioLocal.isChecked()
+        settings.useWasmOpusDecoder = this.useWasmOpusDecoder.isChecked()
         settings.audioSampleQueueSize = parseInt(this.audioSampleQueueSize.getValue())
 
         settings.mouseScrollMode = this.mouseScrollMode.getValue() as any

--- a/web/default_settings.ts
+++ b/web/default_settings.ts
@@ -24,6 +24,7 @@ const trueDefaultSettings: Settings =
     // Canvas only: when true, draw only on requestAnimationFrame (stable, may add ~0–17 ms). When false, draw on frame submit (low latency).
     "canvasVsync": false,
     "playAudioLocal": false,
+    "useWasmOpusDecoder": false,
     "audioSampleQueueSize": 20,
     // possible values: "highres", "normal"
     "mouseScrollMode": "highres",

--- a/web/libopus/index.ts
+++ b/web/libopus/index.ts
@@ -64,24 +64,26 @@ export class OpusMultistreamDecoder {
         this.channels = channels
 
         const stackTop = module.stackSave()
+        let error = OPUS_OK
+        try {
+            const mappingPtr = module.stackAlloc(mappings.length)
+            for (let index = 0; index < channels; index++) {
+                const mapping = mappings[index]
 
-        const mappingPtr = module.stackAlloc(mappings.length)
-        for (let index = 0; index < channels; index++) {
-            const mapping = mappings[index]
-
-            if (mapping < 0 || mapping > 255) {
-                throw new OpusError(OPUS_BAD_ARG)
+                if (mapping < 0 || mapping > 255) {
+                    throw new OpusError(OPUS_BAD_ARG)
+                }
+                module.HEAPU8[mappingPtr + index] = mapping
             }
-            module.HEAPU8[mappingPtr + index] = mapping
+
+            const errorPtr = module.stackAlloc(4)
+
+            this.ptr = module._opus_multistream_decoder_create(sampleRate, channels, streams, coupled_channels, mappingPtr, errorPtr)
+            error = this.module.getValue(errorPtr, "i32")
+        } finally {
+            module.stackRestore(stackTop)
         }
 
-        const errorPtr = module.stackAlloc(4)
-
-        this.ptr = module._opus_multistream_decoder_create(sampleRate, channels, coupled_channels, streams, mappingPtr, errorPtr)
-
-        module.stackRestore(stackTop)
-
-        const error = this.module.getValue(errorPtr, "i32")
         if (error != OPUS_OK) {
             throw new OpusError(error)
         }
@@ -120,13 +122,13 @@ export class OpusMultistreamDecoder {
 
         this.outputBuffer.ensureSize(outputSize)
 
-        const result = this.module._opus_multistream_decode_float(this.ptr, this.inputBuffer.getPtr(), input?.byteLength ?? 0, this.outputBuffer.getPtr(), frameSize, decodeFec ? 1 : 0)
+        const result = this.module._opus_multistream_decode_float(this.ptr, input ? this.inputBuffer.getPtr() : 0, input?.byteLength ?? 0, this.outputBuffer.getPtr(), frameSize, decodeFec ? 1 : 0)
 
         if (result < 0) {
             throw new OpusError(result)
         }
 
-        const outputBuffer = this.outputBuffer.asBufferF32(0, this.channels * frameSize)
+        const outputBuffer = this.outputBuffer.asBufferF32(0, this.channels * result)
         output.set(outputBuffer)
 
         return result
@@ -197,7 +199,7 @@ class Buffer {
         }
 
         this.checkPtr()
-        if ((offsetF32 + lengthF32) * 4 < this.length || offsetF32 < 0 || lengthF32 < 0) {
+        if ((offsetF32 + lengthF32) * 4 > this.length || offsetF32 < 0 || lengthF32 < 0) {
             throw "BufferOutOfBounds"
         }
 

--- a/web/locales/en.ts
+++ b/web/locales/en.ts
@@ -61,6 +61,7 @@ export const en = {
         enableHdr: "Enable HDR",
         audio: "Audio",
         playAudioLocal: "Play Audio Local",
+        useWasmOpusDecoder: "Use WASM Opus Decoder",
         audioSampleQueueSize: "Audio Sample Queue Size",
         mouse: "Mouse",
         scrollMode: "Scroll Mode",

--- a/web/locales/fr-FR.ts
+++ b/web/locales/fr-FR.ts
@@ -63,6 +63,7 @@ export const frFr: Translations = {
         enableHdr: "Activer HDR",
         audio: "Audio",
         playAudioLocal: "Jouer l'auudio localement",
+        useWasmOpusDecoder: "Utiliser le decodeur Opus WASM",
         audioSampleQueueSize: "Taille de la file d'attente audio",
         mouse: "Souris",
         scrollMode: "Mode de défilement",

--- a/web/locales/ko-KR.ts
+++ b/web/locales/ko-KR.ts
@@ -63,6 +63,7 @@ export const koKR: Translations = {
         enableHdr: "HDR 활성화",
         audio: "오디오",
         playAudioLocal: "로컬 오디오 재생",
+        useWasmOpusDecoder: "WASM Opus 디코더 사용",
         audioSampleQueueSize: "오디오 샘플 대기열 크기",
         mouse: "마우스",
         scrollMode: "스크롤 모드",

--- a/web/locales/pt-BR.ts
+++ b/web/locales/pt-BR.ts
@@ -63,6 +63,7 @@ export const ptBR: Translations = {
         enableHdr: "Ativar HDR",
         audio: "Áudio",
         playAudioLocal: "Reproduzir Áudio Localmente",
+        useWasmOpusDecoder: "Usar Decodificador Opus WASM",
         audioSampleQueueSize: "Tamanho da Fila de Amostras de Áudio",
         mouse: "Mouse",
         scrollMode: "Modo de Rolagem",

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -63,6 +63,7 @@ export const zhCN: Translations = {
         enableHdr: "启用 HDR",
         audio: "音频",
         playAudioLocal: "本地播放音频",
+        useWasmOpusDecoder: "使用 WASM Opus 解码器",
         audioSampleQueueSize: "音频采样队列大小",
         mouse: "鼠标",
         scrollMode: "滚动模式",

--- a/web/stream/audio/depacketize_pipe.ts
+++ b/web/stream/audio/depacketize_pipe.ts
@@ -37,8 +37,8 @@ export class DepacketizeAudioPipe implements DataPipe {
     submitPacket(buffer: ArrayBuffer) {
         this.base.decodeAndPlay({
             data: buffer,
-            timestampMicroseconds: 0,
-            durationMicroseconds: 0,
+            timestampMicroseconds: this.timestampMicroseconds,
+            durationMicroseconds: this.packetDurationMicroseconds,
         })
 
         this.timestampMicroseconds += this.packetDurationMicroseconds

--- a/web/stream/audio/opus_decoder_pipe.ts
+++ b/web/stream/audio/opus_decoder_pipe.ts
@@ -110,7 +110,7 @@ export class OpusAudioDecoderPipe implements DataAudioPlayer {
         }
 
         for (let channelIndex = 0; channelIndex < channels; channelIndex++) {
-            if (this.channelBuffers[channelIndex].byteLength < samplesDecoded) {
+            if (this.channelBuffers[channelIndex].length != samplesDecoded) {
                 this.channelBuffers[channelIndex] = new Float32Array(samplesDecoded)
             }
 

--- a/web/stream/audio/pipeline.ts
+++ b/web/stream/audio/pipeline.ts
@@ -21,6 +21,7 @@ type PipelineResult<T> = { audioPlayer: T, error: false } | { audioPlayer: null,
 interface AudioPlayerStatic extends PipeInfoStatic, OutputPipeStatic { }
 
 export type AudioPipelineOptions = {
+    useWasmOpusDecoder?: boolean
 }
 
 type Pipeline = { input: string, pipes: Array<PipeStatic>, player: AudioPlayerStatic }
@@ -62,6 +63,12 @@ export async function buildAudioPipeline(type: string, settings: AudioPipelineOp
     logger?.debug(`Building audio pipeline with output "${type}"`)
 
     let pipelines = PIPELINES
+    if (settings.useWasmOpusDecoder) {
+        pipelines = [
+            ...PIPELINES.filter(pipeline => pipeline.pipes.indexOf(OpusAudioDecoderPipe) != -1),
+            ...PIPELINES.filter(pipeline => pipeline.pipes.indexOf(OpusAudioDecoderPipe) == -1),
+        ]
+    }
 
     pipelineLoop: for (const pipeline of pipelines) {
         if (pipeline.input != type) {

--- a/web/stream/index.ts
+++ b/web/stream/index.ts
@@ -515,7 +515,7 @@ export class Stream implements Component {
             return "failednoconnect"
         }
 
-        const transport = new WebRTCTransport(this.logger)
+        const transport = new WebRTCTransport(this.logger, { useDataAudio: this.settings.useWasmOpusDecoder })
         transport.onsendmessage = (message) => this.sendWsMessage({ WebRtc: message })
 
         transport.initPeer({
@@ -720,7 +720,7 @@ export class Stream implements Component {
             return false
         }
 
-        this.transport.setupHostAudio({
+        await this.transport.setupHostAudio({
             type: ["audiotrack", "data"]
         })
 
@@ -765,6 +765,7 @@ export class Stream implements Component {
             width: this.streamerSize[0],
             height: this.streamerSize[1],
             play_audio_local: this.settings.playAudioLocal,
+            use_wasm_opus_decoder: this.settings.useWasmOpusDecoder,
             supported_codecs: createSupportedVideoFormatsBits(videoCodecSupport),
             hdr: this.settings.hdr ?? false,
         }

--- a/web/stream/transport/webrtc.ts
+++ b/web/stream/transport/webrtc.ts
@@ -8,11 +8,13 @@ export class WebRTCTransport implements Transport {
     implementationName: string = "webrtc"
 
     private logger: Logger | null
+    private useDataAudio: boolean
 
     private peer: RTCPeerConnection | null = null
 
-    constructor(logger?: Logger) {
+    constructor(logger?: Logger, options?: { useDataAudio?: boolean }) {
         this.logger = logger ?? null
+        this.useDataAudio = options?.useDataAudio ?? false
     }
 
     async initPeer(configuration?: RTCConfiguration) {
@@ -239,8 +241,12 @@ export class WebRTCTransport implements Transport {
                 continue
             }
             if (channel == "HOST_AUDIO") {
-                const channel: AudioTrackTransportChannel = new WebRTCInboundTrackTransportChannel<"audiotrack">(this.logger, "audiotrack", "audio", this.audioTrackHolder)
-                this.channels[TransportChannelId.HOST_AUDIO] = channel
+                if (this.useDataAudio) {
+                    this.channels[TransportChannelId.HOST_AUDIO] = new WebRTCDataTransportChannel(channel, null)
+                } else {
+                    const channel: AudioTrackTransportChannel = new WebRTCInboundTrackTransportChannel<"audiotrack">(this.logger, "audiotrack", "audio", this.audioTrackHolder)
+                    this.channels[TransportChannelId.HOST_AUDIO] = channel
+                }
                 continue
             }
 
@@ -355,8 +361,15 @@ export class WebRTCTransport implements Transport {
         }
     }
 
-    async setupHostAudio(_setup: TransportAudioSetup): Promise<void> {
-        // TODO: check transport type
+    async setupHostAudio(setup: TransportAudioSetup): Promise<void> {
+        if (this.useDataAudio && setup.type.indexOf("data") == -1) {
+            this.logger?.debug("Cannot use WebRTC data audio: Found no supported audio pipeline")
+            throw "Cannot use WebRTC data audio: Found no supported audio pipeline"
+        }
+        if (!this.useDataAudio && setup.type.indexOf("audiotrack") == -1) {
+            this.logger?.debug("Cannot use WebRTC track audio: Found no supported audio pipeline")
+            throw "Cannot use WebRTC track audio: Found no supported audio pipeline"
+        }
     }
 
     getChannel(id: TransportChannelIdValue): TransportChannel {
@@ -524,6 +537,9 @@ class WebRTCDataTransportChannel implements DataTransportChannel {
 
         this.logger = logger ?? null
 
+        if (this.channel) {
+            this.channel.binaryType = "arraybuffer"
+        }
         this.channel?.addEventListener("message", this.boundOnMessage)
     }
 
@@ -536,6 +552,7 @@ class WebRTCDataTransportChannel implements DataTransportChannel {
         this.channel?.removeEventListener("message", this.boundOnMessage)
         // Add listener to new channel
         this.channel = newChannel
+        this.channel.binaryType = "arraybuffer"
         this.channel.addEventListener("open", this.boundTryDequeueSendQueue)
         this.channel.addEventListener("message", this.boundOnMessage)
     }


### PR DESCRIPTION
* Fix some browsers couldn't decode opus in native.
* If `Use WASM decode` is enabled, opus packets will be sent via the RTC data channel.