### PR TITLE
Scuffed on-screen controller

### DIFF
--- a/stream.html
+++ b/stream.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en" class="stream notranslate">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widgets=overlays-content" />
+    <title>Stream</title>
+    <link rel="icon" href="resources/moonlight.svg" sizes="any" type="image/svg+xml">
+
+    <link rel="stylesheet" href="styles/standard.css" id="style">
+    <script type="module" src="styles/index.js"></script>
+
+    <script type="module" src="stream.js" defer></script>
+
+    <script>
+        try {
+            const raw = localStorage.getItem("mlSettings");
+            const parsed = raw ? JSON.parse(raw) : null;
+            const language = parsed && (parsed.language === "zh-CN" || parsed.language === "zh" || parsed.language === "zh_CN")
+                ? "zh-CN"
+                : "en";
+            document.documentElement.lang = language;
+            document.documentElement.translate = false;
+            document.documentElement.classList.add("notranslate");
+        } catch (_err) { }
+    </script>
+</head>
+
+<body class="stream">
+    <style>
+        #controller-overlay {
+            position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+            z-index: 99998; pointer-events: none; display: none;
+        }
+        #controller-overlay.active { pointer-events: auto; display: block; }
+        .vbtn {
+            pointer-events: auto; position: absolute;
+            background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.4);
+            border-radius: 50%; touch-action: none;
+            display: flex; align-items: center; justify-content: center;
+            color: white; font-weight: 500; font-family: sans-serif;
+            user-select: none; -webkit-user-select: none;
+        }
+        .btn-round { width: 60px; height: 60px; font-size: 18px; }
+        .sidebar-button-active { background: rgba(255, 255, 255, 0.3) !important; color: #ff5722 !important; }
+        
+        /* POSITIONS */
+        #btn-lt { top: 30px; left: 50px; } #btn-lb { top: 30px; left: 140px; }
+        #btn-rt { top: 30px; right: 50px; } #btn-rb { top: 30px; right: 140px; }
+        #btn-select { top: 30px; left: calc(50% - 110px); font-size: 24px; }
+        #btn-guide { top: 20px; left: calc(50% - 35px); width: 70px; height: 70px; font-size: 28px; }
+        #btn-start { top: 30px; left: calc(50% + 50px); font-size: 24px; }
+        #btn-y { bottom: 350px; right: 130px; } #btn-a { bottom: 210px; right: 130px; }
+        #btn-x { bottom: 280px; right: 200px; } #btn-b { bottom: 280px; right: 60px; }
+        #btn-up { bottom: 350px; left: 130px; } #btn-down { bottom: 210px; left: 130px; }
+        #btn-left { bottom: 280px; left: 60px; } #btn-right { bottom: 280px; left: 200px; }
+        #btn-l3 { bottom: 40px; left: 50px; } #btn-r3 { bottom: 40px; right: 50px; }
+
+        .joystick-zone {
+            position: absolute; pointer-events: auto; touch-action: none;
+            width: 140px; height: 140px; border-radius: 50%;
+            background: rgba(0, 0, 0, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+        .joystick-knob {
+            position: absolute; top: 35px; left: 35px;
+            width: 70px; height: 70px; border-radius: 50%;
+            background: rgba(255, 255, 255, 0.75); box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+            pointer-events: none; transition: transform 0.05s linear;
+        }
+        #joy-left { bottom: 60px; left: 220px; } #joy-right { bottom: 60px; right: 220px; } 
+    </style>
+
+    <div id="controller-overlay">
+        <div id="btn-lt" class="vbtn btn-round">LT</div>
+        <div id="btn-lb" class="vbtn btn-round">LB</div>
+        <div id="btn-rt" class="vbtn btn-round">RT</div>
+        <div id="btn-rb" class="vbtn btn-round">RB</div>
+        <div id="btn-select" class="vbtn btn-round">◀</div>
+        <div id="btn-guide" class="vbtn btn-round">🎮</div>
+        <div id="btn-start" class="vbtn btn-round">▶</div>
+        <div id="btn-a" class="vbtn btn-round">A</div>
+        <div id="btn-b" class="vbtn btn-round">B</div>
+        <div id="btn-x" class="vbtn btn-round">X</div>
+        <div id="btn-y" class="vbtn btn-round">Y</div>
+        <div id="btn-up" class="vbtn btn-round">▲</div>
+        <div id="btn-down" class="vbtn btn-round">▼</div>
+        <div id="btn-left" class="vbtn btn-round">◀</div>
+        <div id="btn-right" class="vbtn btn-round">▶</div>
+        <div id="btn-l3" class="vbtn btn-round">L3</div>
+        <div id="btn-r3" class="vbtn btn-round">R3</div>
+        <div id="joy-left" class="joystick-zone"><div class="joystick-knob" id="knob-left"></div></div>
+        <div id="joy-right" class="joystick-zone"><div class="joystick-knob" id="knob-right"></div></div>
+    </div>
+
+    <script>
+        // 1. Core API Hijack
+        window.vGamepad = {
+            id: "Xbox 360 Controller (Standard Gamepad)", index: 0, mapping: "standard", 
+            connected: false, timestamp: performance.now(), axes: [0, 0, 0, 0],
+            buttons: new Array(17).fill(0).map(() => ({ pressed: false, touched: false, value: 0 }))
+        };
+
+        const originalGetGamepads = navigator.getGamepads || navigator.webkitGetGamepads;
+        navigator.getGamepads = function() {
+            const realPads = originalGetGamepads ? Array.from(originalGetGamepads.call(navigator)) : [];
+            if (window.vGamepad.connected) {
+                window.vGamepad.timestamp = performance.now();
+                return [window.vGamepad, ...realPads.filter(p => p !== null)];
+            }
+            return [...realPads.filter(p => p !== null)];
+        };
+
+        // 2. Global Actions for the Sidebar to call
+        window.toggleVirtualGamepad = function(btn) {
+            const overlay = document.getElementById('controller-overlay');
+            const isVisible = overlay.style.display === 'block';
+            
+            if (isVisible) {
+                overlay.style.display = 'none';
+                if (btn) btn.classList.remove('sidebar-button-active');
+            } else {
+                overlay.style.display = 'block';
+                if (btn) btn.classList.add('sidebar-button-active');
+                
+                if (!window.vGamepad.connected) {
+                    window.vGamepad.connected = true;
+                    const event = new Event('gamepadconnected');
+                    event.gamepad = window.vGamepad;
+                    window.dispatchEvent(event);
+                }
+            }
+        };
+
+        window.unplugVirtualGamepad = function(btn) {
+            window.vGamepad.connected = false;
+            document.getElementById('controller-overlay').style.display = 'none';
+            if (btn) {
+                btn.classList.remove('sidebar-button-active');
+                const originalText = btn.innerText;
+                btn.innerText = 'Unplugged';
+                btn.style.color = 'white';
+                btn.style.background = 'rgba(255, 60, 60, 0.8)';
+                setTimeout(() => {
+                    btn.innerText = originalText;
+                    btn.style.background = '';
+                    btn.style.color = '';
+                }, 1000);
+            }
+            const event = new Event('gamepaddisconnected');
+            event.gamepad = window.vGamepad;
+            window.dispatchEvent(event);
+        };
+
+        // 3. UI Interaction Engine
+        function blockEvent(e) { e.preventDefault(); e.stopImmediatePropagation(); return false; }
+        const overlay = document.getElementById('controller-overlay');
+        ['touchstart', 'touchmove', 'touchend', 'touchcancel', 'pointerdown', 'pointermove', 'pointerup'].forEach(evt => {
+            overlay.addEventListener(evt, blockEvent, { passive: false });
+        });
+
+        const btnMap = { 'btn-a': 1, 'btn-b': 0, 'btn-x': 3, 'btn-y': 2, 'btn-lb': 4, 'btn-rb': 5, 'btn-lt': 6, 'btn-rt': 7, 'btn-select': 8, 'btn-start': 9, 'btn-l3': 10, 'btn-r3': 11, 'btn-up': 12, 'btn-down': 13, 'btn-left': 14, 'btn-right': 15, 'btn-guide': 16};
+        function setButton(idx, pressed) {
+            window.vGamepad.buttons[idx].pressed = pressed;
+            window.vGamepad.buttons[idx].touched = pressed;
+            window.vGamepad.buttons[idx].value = pressed ? 1.0 : 0.0;
+        }
+
+        Object.keys(btnMap).forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.addEventListener('touchstart', (e) => { e.preventDefault(); e.stopImmediatePropagation(); setButton(btnMap[id], true); el.style.background = "rgba(255, 255, 255, 0.4)"; }, { passive: false });
+                el.addEventListener('touchend', (e) => { e.preventDefault(); e.stopImmediatePropagation(); setButton(btnMap[id], false); el.style.background = "rgba(0, 0, 0, 0.25)"; }, { passive: false });
+            }
+        });
+
+        // Fixed Joystick - Whole Zone Moves + Clean Initial Touch
+        function setupJoystick(zoneId, knobId, axisX, axisY) {
+            const zone = document.getElementById(zoneId);
+            const knob = document.getElementById(knobId);
+            if (!zone || !knob) return;
+            
+            const maxDistance = 35;
+            let originalBottom = null;
+            let originalLeft = null;
+            let originalRight = null;
+            let isActive = false;
+            let hasMoved = false;
+
+            function updateStick(e) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                
+                const touch = e.targetTouches[0];
+                if (!touch) return;
+
+                const rect = zone.getBoundingClientRect();
+
+                if (!isActive) {
+                    isActive = true;
+                    hasMoved = false;
+                    
+                    // Save original position
+                    originalBottom = zone.style.bottom || '60px';
+                    if (zone.id === 'joy-left') originalLeft = zone.style.left || '220px';
+                    if (zone.id === 'joy-right') originalRight = zone.style.right || '220px';
+
+                    // Move whole zone to finger
+                    zone.style.transition = 'none';
+                    zone.style.bottom = (window.innerHeight - touch.clientY - 70) + 'px';
+                    
+                    if (zone.id === 'joy-left') {
+                        zone.style.left = (touch.clientX - 70) + 'px';
+                    } else {
+                        zone.style.right = (window.innerWidth - touch.clientX - 70) + 'px';
+                    }
+                    
+                    // Reset knob
+                    knob.style.transition = 'none';
+                    knob.style.transform = 'translate(0px, 0px)';
+                    return; // Don't send input on initial touch
+                }
+
+                // User has started moving
+                hasMoved = true;
+
+                let dx = touch.clientX - (rect.left + rect.width / 2);
+                let dy = touch.clientY - (rect.top + rect.height / 2);
+                
+                const distance = Math.sqrt(dx*dx + dy*dy);
+                if (distance > maxDistance) {
+                    dx = (dx / distance) * maxDistance;
+                    dy = (dy / distance) * maxDistance;
+                }
+
+                knob.style.transform = `translate(${dx}px, ${dy}px)`;
+                
+                window.vGamepad.axes[axisX] = dx / maxDistance;
+                window.vGamepad.axes[axisY] = dy / maxDistance;
+            }
+
+            function resetStick(e) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                
+                // Return zone to original position smoothly
+                zone.style.transition = 'all 0.25s ease-out';
+                zone.style.bottom = originalBottom;
+                if (zone.id === 'joy-left' && originalLeft) zone.style.left = originalLeft;
+                if (zone.id === 'joy-right' && originalRight) zone.style.right = originalRight;
+                
+                knob.style.transition = 'transform 0.2s ease-out';
+                knob.style.transform = 'translate(0px, 0px)';
+                
+                window.vGamepad.axes[axisX] = 0;
+                window.vGamepad.axes[axisY] = 0;
+
+                isActive = false;
+                hasMoved = false;
+            }
+
+            zone.addEventListener('touchstart', updateStick, { passive: false });
+            zone.addEventListener('touchmove', updateStick, { passive: false });
+            zone.addEventListener('touchend', resetStick, { passive: false });
+            zone.addEventListener('touchcancel', resetStick, { passive: false });
+        }
+        setupJoystick('joy-left', 'knob-left', 0, 1);
+        setupJoystick('joy-right', 'knob-right', 2, 3);
+    </script>
+
+    <!-- Modal -->
+    <div id="modal-overlay" class="modal-background modal-disabled">
+        <!-- Modal Content -->
+        <div id="modal-parent" class="modal-content">
+        </div>
+    </div>
+
+    <!-- Sidebar -->
+    <div class="sidebar-overlay prevent-start-transition" id="sidebar-root">
+        <div class="sidebar-background prevent-start-transition">
+            <button id="sidebar-button" class="sidebar-button"><img src="resources/arrow_left.svg"
+                    class="sidebar-button-image prevent-start-transition" /></button>
+            <div id="sidebar-parent" class="sidebar-content">
+            </div>
+        </div>
+    </div>
+
+    <!-- Notification -->
+    <div id="notification-list">
+    </div>
+
+    <!-- A dummy element for capturing inputs -->
+    <div id="input" tabindex="0"></div>
+
+    <!-- Main App View -->
+    <div id="root">
+    </div>
+
+</body>
+
+</html>

--- a/web/stream.html
+++ b/web/stream.html
@@ -29,6 +29,244 @@
 </head>
 
 <body class="stream">
+    <style>
+        #controller-overlay {
+            position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+            z-index: 99998; pointer-events: none; display: none;
+        }
+        #controller-overlay.active { pointer-events: auto; display: block; }
+        .vbtn {
+            pointer-events: auto; position: absolute;
+            background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.4);
+            border-radius: 50%; touch-action: none;
+            display: flex; align-items: center; justify-content: center;
+            color: white; font-weight: 500; font-family: sans-serif;
+            user-select: none; -webkit-user-select: none;
+        }
+        .btn-round { width: 60px; height: 60px; font-size: 18px; }
+        .sidebar-button-active { background: rgba(255, 255, 255, 0.3) !important; color: #ff5722 !important; }
+        
+        /* POSITIONS */
+        #btn-lt { top: 30px; left: 50px; } #btn-lb { top: 30px; left: 140px; }
+        #btn-rt { top: 30px; right: 50px; } #btn-rb { top: 30px; right: 140px; }
+        #btn-select { top: 30px; left: calc(50% - 110px); font-size: 24px; }
+        #btn-start { top: 30px; left: calc(50% + 50px); font-size: 24px; }
+        #btn-y { bottom: 350px; right: 130px; } #btn-a { bottom: 210px; right: 130px; }
+        #btn-x { bottom: 280px; right: 200px; } #btn-b { bottom: 280px; right: 60px; }
+        #btn-up { bottom: 350px; left: 130px; } #btn-down { bottom: 210px; left: 130px; }
+        #btn-left { bottom: 280px; left: 60px; } #btn-right { bottom: 280px; left: 200px; }
+        #btn-l3 { bottom: 40px; left: 50px; } #btn-r3 { bottom: 40px; right: 50px; }
+
+        .joystick-zone {
+            position: absolute; pointer-events: auto; touch-action: none;
+            width: 140px; height: 140px; border-radius: 50%;
+            background: rgba(0, 0, 0, 0.1); border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+        .joystick-knob {
+            position: absolute; top: 35px; left: 35px;
+            width: 70px; height: 70px; border-radius: 50%;
+            background: rgba(255, 255, 255, 0.75); box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+            pointer-events: none; transition: transform 0.05s linear;
+        }
+        #joy-left { bottom: 60px; left: 220px; } #joy-right { bottom: 60px; right: 220px; } 
+    </style>
+
+    <div id="controller-overlay">
+        <div id="btn-lt" class="vbtn btn-round">LT</div>
+        <div id="btn-lb" class="vbtn btn-round">LB</div>
+        <div id="btn-rt" class="vbtn btn-round">RT</div>
+        <div id="btn-rb" class="vbtn btn-round">RB</div>
+        <div id="btn-select" class="vbtn btn-round">◀</div>
+        <div id="btn-start" class="vbtn btn-round">▶</div>
+        <div id="btn-a" class="vbtn btn-round">A</div>
+        <div id="btn-b" class="vbtn btn-round">B</div>
+        <div id="btn-x" class="vbtn btn-round">X</div>
+        <div id="btn-y" class="vbtn btn-round">Y</div>
+        <div id="btn-up" class="vbtn btn-round">▲</div>
+        <div id="btn-down" class="vbtn btn-round">▼</div>
+        <div id="btn-left" class="vbtn btn-round">◀</div>
+        <div id="btn-right" class="vbtn btn-round">▶</div>
+        <div id="btn-l3" class="vbtn btn-round">L3</div>
+        <div id="btn-r3" class="vbtn btn-round">R3</div>
+        <div id="joy-left" class="joystick-zone"><div class="joystick-knob" id="knob-left"></div></div>
+        <div id="joy-right" class="joystick-zone"><div class="joystick-knob" id="knob-right"></div></div>
+    </div>
+
+    <script>
+        // 1. Core API Hijack
+        window.vGamepad = {
+            id: "Xbox 360 Controller (Standard Gamepad)", index: 0, mapping: "standard", 
+            connected: false, timestamp: performance.now(), axes: [0, 0, 0, 0],
+            buttons: new Array(17).fill(0).map(() => ({ pressed: false, touched: false, value: 0 }))
+        };
+
+        const originalGetGamepads = navigator.getGamepads || navigator.webkitGetGamepads;
+        navigator.getGamepads = function() {
+            const realPads = originalGetGamepads ? Array.from(originalGetGamepads.call(navigator)) : [];
+            if (window.vGamepad.connected) {
+                window.vGamepad.timestamp = performance.now();
+                return [window.vGamepad, ...realPads.filter(p => p !== null)];
+            }
+            return [...realPads.filter(p => p !== null)];
+        };
+
+        // 2. Global Actions for the Sidebar to call
+        window.toggleVirtualGamepad = function(btn) {
+            const overlay = document.getElementById('controller-overlay');
+            const isVisible = overlay.style.display === 'block';
+            
+            if (isVisible) {
+                overlay.style.display = 'none';
+                if (btn) btn.classList.remove('sidebar-button-active');
+            } else {
+                overlay.style.display = 'block';
+                if (btn) btn.classList.add('sidebar-button-active');
+                
+                if (!window.vGamepad.connected) {
+                    window.vGamepad.connected = true;
+                    const event = new Event('gamepadconnected');
+                    event.gamepad = window.vGamepad;
+                    window.dispatchEvent(event);
+                }
+            }
+        };
+
+        window.unplugVirtualGamepad = function(btn) {
+            window.vGamepad.connected = false;
+            document.getElementById('controller-overlay').style.display = 'none';
+            if (btn) {
+                btn.classList.remove('sidebar-button-active');
+                const originalText = btn.innerText;
+                btn.innerText = 'Unplugged';
+                btn.style.color = 'white';
+                btn.style.background = 'rgba(255, 60, 60, 0.8)';
+                setTimeout(() => {
+                    btn.innerText = originalText;
+                    btn.style.background = '';
+                    btn.style.color = '';
+                }, 1000);
+            }
+            const event = new Event('gamepaddisconnected');
+            event.gamepad = window.vGamepad;
+            window.dispatchEvent(event);
+        };
+
+        // 3. UI Interaction Engine
+        function blockEvent(e) { e.preventDefault(); e.stopImmediatePropagation(); return false; }
+        const overlay = document.getElementById('controller-overlay');
+        ['touchstart', 'touchmove', 'touchend', 'touchcancel', 'pointerdown', 'pointermove', 'pointerup'].forEach(evt => {
+            overlay.addEventListener(evt, blockEvent, { passive: false });
+        });
+
+        const btnMap = { 'btn-a': 1, 'btn-b': 0, 'btn-x': 3, 'btn-y': 2, 'btn-lb': 4, 'btn-rb': 5, 'btn-lt': 6, 'btn-rt': 7, 'btn-select': 8, 'btn-start': 9, 'btn-l3': 10, 'btn-r3': 11, 'btn-up': 12, 'btn-down': 13, 'btn-left': 14, 'btn-right': 15 };
+        function setButton(idx, pressed) {
+            window.vGamepad.buttons[idx].pressed = pressed;
+            window.vGamepad.buttons[idx].touched = pressed;
+            window.vGamepad.buttons[idx].value = pressed ? 1.0 : 0.0;
+        }
+
+        Object.keys(btnMap).forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.addEventListener('touchstart', (e) => { e.preventDefault(); e.stopImmediatePropagation(); setButton(btnMap[id], true); el.style.background = "rgba(255, 255, 255, 0.4)"; }, { passive: false });
+                el.addEventListener('touchend', (e) => { e.preventDefault(); e.stopImmediatePropagation(); setButton(btnMap[id], false); el.style.background = "rgba(0, 0, 0, 0.25)"; }, { passive: false });
+            }
+        });
+
+        // Fixed Joystick - Whole Zone Moves + Clean Initial Touch
+        function setupJoystick(zoneId, knobId, axisX, axisY) {
+            const zone = document.getElementById(zoneId);
+            const knob = document.getElementById(knobId);
+            if (!zone || !knob) return;
+            
+            const maxDistance = 35;
+            let originalBottom = null;
+            let originalLeft = null;
+            let originalRight = null;
+            let isActive = false;
+            let hasMoved = false;
+
+            function updateStick(e) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                
+                const touch = e.targetTouches[0];
+                if (!touch) return;
+
+                const rect = zone.getBoundingClientRect();
+
+                if (!isActive) {
+                    isActive = true;
+                    hasMoved = false;
+                    
+                    // Save original position
+                    originalBottom = zone.style.bottom || '60px';
+                    if (zone.id === 'joy-left') originalLeft = zone.style.left || '220px';
+                    if (zone.id === 'joy-right') originalRight = zone.style.right || '220px';
+
+                    // Move whole zone to finger
+                    zone.style.transition = 'none';
+                    zone.style.bottom = (window.innerHeight - touch.clientY - 70) + 'px';
+                    
+                    if (zone.id === 'joy-left') {
+                        zone.style.left = (touch.clientX - 70) + 'px';
+                    } else {
+                        zone.style.right = (window.innerWidth - touch.clientX - 70) + 'px';
+                    }
+                    
+                    // Reset knob
+                    knob.style.transition = 'none';
+                    knob.style.transform = 'translate(0px, 0px)';
+                    return; // Don't send input on initial touch
+                }
+
+                // User has started moving
+                hasMoved = true;
+
+                let dx = touch.clientX - (rect.left + rect.width / 2);
+                let dy = touch.clientY - (rect.top + rect.height / 2);
+                
+                const distance = Math.sqrt(dx*dx + dy*dy);
+                if (distance > maxDistance) {
+                    dx = (dx / distance) * maxDistance;
+                    dy = (dy / distance) * maxDistance;
+                }
+
+                knob.style.transform = `translate(${dx}px, ${dy}px)`;
+                
+                window.vGamepad.axes[axisX] = dx / maxDistance;
+                window.vGamepad.axes[axisY] = dy / maxDistance;
+            }
+
+            function resetStick(e) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                
+                // Return zone to original position smoothly
+                zone.style.transition = 'all 0.25s ease-out';
+                zone.style.bottom = originalBottom;
+                if (zone.id === 'joy-left' && originalLeft) zone.style.left = originalLeft;
+                if (zone.id === 'joy-right' && originalRight) zone.style.right = originalRight;
+                
+                knob.style.transition = 'transform 0.2s ease-out';
+                knob.style.transform = 'translate(0px, 0px)';
+                
+                window.vGamepad.axes[axisX] = 0;
+                window.vGamepad.axes[axisY] = 0;
+
+                isActive = false;
+                hasMoved = false;
+            }
+
+            zone.addEventListener('touchstart', updateStick, { passive: false });
+            zone.addEventListener('touchmove', updateStick, { passive: false });
+            zone.addEventListener('touchend', resetStick, { passive: false });
+            zone.addEventListener('touchcancel', resetStick, { passive: false });
+        }
+        setupJoystick('joy-left', 'knob-left', 0, 1);
+        setupJoystick('joy-right', 'knob-right', 2, 3);
+    </script>
+    
     <!-- Modal -->
     <div id="modal-overlay" class="modal-background modal-disabled">
         <!-- Modal Content -->

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -6,14 +6,22 @@ import { InfoEvent, Stream } from "./stream/index.js"
 import { getModalBackground, Modal, showMessage, showModal } from "./component/modal/index.js";
 import { getSidebarRoot, setSidebar, setSidebarExtended, setSidebarStyle, Sidebar } from "./component/sidebar/index.js";
 import { defaultStreamInputConfig, MouseMode, ScreenKeyboardSetVisibleEvent, StreamInputConfig } from "./stream/input.js";
-import { getLocalStreamSettings, Settings, TransportType} from "./component/settings_menu.js";
+import { getLocalStreamSettings, Settings, TransportType } from "./component/settings_menu.js";
 import { SelectComponent } from "./component/input.js";
 import { DetailedRole, LogMessageType, StreamCapabilities, StreamKeys, StreamPermissions } from "./api_bindings.js";
 import { KeyboardModeEvent, KeyboardModeWillChangeEvent, ScreenKeyboard, TextEvent } from "./screen_keyboard.js";
 import { FormModal } from "./component/modal/form.js";
 import { streamStatsToText } from "./stream/stats.js";
-import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations, Language, normalizeLanguage} from "./i18n.js";
+import { adoptRoleDefaultLanguage, getCurrentLanguage, getTranslations, Language, normalizeLanguage } from "./i18n.js";
 import { requestKeyboardLock } from "./iframe.js";
+
+declare global {
+    interface Window {
+        vGamepad?: any;
+        toggleVirtualGamepad?: (btn: HTMLButtonElement) => void;
+        unplugVirtualGamepad?: (btn: HTMLButtonElement) => void;
+    }
+}
 
 let I = getTranslations(getCurrentLanguage())
 
@@ -1003,6 +1011,8 @@ class AutoFullscreenModal implements Component, Modal<void> {
 class ViewerSidebar implements Component, Sidebar {
     private app: ViewerApp
 
+    private gamepadButton = document.createElement("button");
+
     private div = document.createElement("div")
 
     private buttonDiv = document.createElement("div")
@@ -1030,6 +1040,57 @@ class ViewerSidebar implements Component, Sidebar {
 
         this.buttonDiv.classList.add("sidebar-stream-buttons")
         this.div.appendChild(this.buttonDiv)
+
+        // Configure divs
+        this.div.classList.add("sidebar-stream")
+
+        this.buttonDiv.classList.add("sidebar-stream-buttons")
+        this.div.appendChild(this.buttonDiv)
+
+        // --- VIRTUAL GAMEPAD BUTTON (First button) ---
+        this.gamepadButton = document.createElement("button");
+        this.gamepadButton.innerText = "Gamepad";
+        this.gamepadButton.id = "vpad-btn";
+        this.gamepadButton.title = "Virtual Gamepad (Long press to unplug)";
+
+        let pressStartTime = 0;
+        const LONG_PRESS_DURATION = 550;
+
+        const handlePointerDown = (e: PointerEvent) => {
+            if (e.button !== undefined && e.button !== 0) return;
+            pressStartTime = Date.now();
+            this.gamepadButton.style.transition = "background-color 0.15s";
+            this.gamepadButton.style.backgroundColor = "rgba(255, 255, 255, 0.25)";
+        };
+
+        const handlePointerUp = (e: PointerEvent) => {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+
+            const duration = Date.now() - pressStartTime;
+            this.gamepadButton.style.backgroundColor = "";
+
+            if (duration >= LONG_PRESS_DURATION) {
+                window.unplugVirtualGamepad?.(this.gamepadButton);
+            } else {
+                window.toggleVirtualGamepad?.(this.gamepadButton);
+            }
+        };
+
+        this.gamepadButton.addEventListener("pointerdown", handlePointerDown, { passive: false });
+        this.gamepadButton.addEventListener("pointerup", handlePointerUp, { passive: false });
+        this.gamepadButton.addEventListener("pointerleave", () => {
+            this.gamepadButton.style.backgroundColor = "";
+        });
+        this.gamepadButton.addEventListener("pointercancel", () => {
+            this.gamepadButton.style.backgroundColor = "";
+        });
+
+        this.gamepadButton.addEventListener("contextmenu", e => e.preventDefault());
+        this.gamepadButton.addEventListener("click", e => e.preventDefault());
+
+        // Insert as the very first button
+        this.buttonDiv.insertBefore(this.gamepadButton, this.buttonDiv.firstChild);
 
         // Send keycode
         this.sendKeycodeButton.innerText = I.stream.sendKeycode


### PR DESCRIPTION
- Added a scuffed on-screen controller using the same layout as GeForce Now (What I got used to)
- Pressing the Gamepad toggle once will "plug" the controller
- Pressing the Gamepad toggle while its active will hide/unhide the controller
- Long pressing the Gamepad toggle will "unplug" the controller
- The Joysticks will move to the finger position and use that as the initial "0,0" location. (Joystick will only move if finger is in its inner part)
<img width="800" height="360" alt="how it works" src="https://github.com/user-attachments/assets/78b80b57-cf01-4fbd-a344-cec60f878de8" />

(Recording was made before I re-added the guide button.. removed it cause I never use it myself)