### PR TITLE
fix timeout when pairing

### DIFF
--- a/web/api.ts
+++ b/web/api.ts
@@ -197,7 +197,9 @@ export async function fetchApi<Initial, Other>(api: Api, endpoint: string, metho
 export async function fetchApi(api: Api, endpoint: string, method: string = GET, init?: { response?: "json" | "ignore" | "jsonStreaming" } & ApiFetchInit, timeout: number = API_TIMEOUT) {
     const [url, request] = buildRequest(api, endpoint, method, init)
 
-    request.signal = AbortSignal.timeout(timeout)
+    if (!init?.noTimeout) {
+        request.signal = AbortSignal.timeout(timeout)
+    }
 
     let response
     try {


### PR DESCRIPTION
See https://github.com/MrCreativ3001/moonlight-web-stream/issues/78#issuecomment-4903219922

>noTimeout: true in apiPostPair (web/api.ts) appears to be dead code — fetchApi's actual timeout comes from a separate function parameter that's never passed through, so the frontend fetch always aborts after API_TIMEOUT (12000ms, web/api.ts line ~8) regardless of that flag. This meant the pairing PIN modal never had a realistic window to be seen/used, since the whole streamed response gets killed client-side after 12s no matter what.