### PR TITLE
feat(auth): add native OpenID Connect login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "brotli",
  "bytes",
@@ -73,7 +73,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -306,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -360,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -397,7 +406,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -409,7 +418,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -420,7 +429,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -440,6 +449,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -479,7 +494,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -534,6 +549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,7 +592,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -644,6 +668,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,7 +681,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -661,10 +702,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -720,7 +775,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -787,10 +842,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -840,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -892,8 +962,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -908,7 +979,41 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -949,6 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -970,7 +1076,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -994,7 +1100,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1016,7 +1122,7 @@ dependencies = [
  "p256",
  "p384",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "rand_core 0.6.4",
  "rcgen",
  "ring",
@@ -1033,6 +1139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1156,30 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1275,7 +1411,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1350,10 +1486,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1395,12 +1534,18 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1544,6 +1689,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1552,18 +1698,45 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1654,6 +1827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1858,17 @@ name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -1712,7 +1902,7 @@ dependencies = [
  "futures",
  "log",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "rtcp",
  "rtp",
  "thiserror 1.0.69",
@@ -1733,6 +1923,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1789,6 +1988,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1811,6 +2013,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -1852,6 +2060,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1995,7 +2209,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2061,6 +2275,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,7 +2313,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2124,6 +2354,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "rand 0.8.7",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -2154,6 +2405,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http 1.4.0",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,7 +2458,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2199,6 +2481,15 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2260,7 +2551,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2296,7 +2587,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2310,6 +2601,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -2333,7 +2635,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2345,7 +2647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2387,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2435,7 +2737,63 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2470,12 +2828,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2504,6 +2894,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2547,6 +2952,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2594,6 +3019,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +3089,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.13.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -2644,7 +3107,7 @@ checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2654,6 +3117,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2674,7 +3157,7 @@ dependencies = [
  "bytes",
  "memchr",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "serde",
  "thiserror 1.0.69",
  "webrtc-util",
@@ -2724,14 +3207,15 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2760,6 +3244,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,7 +3278,7 @@ name = "sdp"
 version = "0.17.1"
 source = "git+https://github.com/MrCreativ3001/webrtc-rs.git?rev=c9675e222245e95c056e2dcc0195fb076ffa9b89#c9675e222245e95c056e2dcc0195fb076ffa9b89"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "substring",
  "thiserror 1.0.69",
  "url",
@@ -2817,6 +3325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,7 +3351,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2850,6 +3368,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,13 +3400,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2879,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2972,6 +3542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,11 +3595,11 @@ name = "stun"
 version = "0.17.1"
 source = "git+https://github.com/MrCreativ3001/webrtc-rs.git?rev=c9675e222245e95c056e2dcc0195fb076ffa9b89#c9675e222245e95c056e2dcc0195fb076ffa9b89"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
- "rand",
+ "rand 0.9.2",
  "ring",
  "subtle",
  "thiserror 1.0.69",
@@ -3059,6 +3635,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,7 +3662,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3104,7 +3700,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3115,7 +3711,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3218,7 +3814,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3254,6 +3850,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3306,7 +3941,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3373,7 +4008,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -3383,12 +4018,12 @@ version = "0.17.1"
 source = "git+https://github.com/MrCreativ3001/webrtc-rs.git?rev=c9675e222245e95c056e2dcc0195fb076ffa9b89#c9675e222245e95c056e2dcc0195fb076ffa9b89"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures",
  "log",
  "md-5",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "ring",
  "stun",
  "thiserror 1.0.69",
@@ -3453,6 +4088,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3581,6 +4217,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,7 +4249,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3629,7 +4279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3642,7 +4292,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3655,6 +4305,7 @@ dependencies = [
  "actix-ws",
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "clap",
  "common",
  "futures",
@@ -3662,6 +4313,7 @@ dependencies = [
  "hex",
  "log",
  "moonlight-common",
+ "openidconnect",
  "openssl",
  "pem",
  "serde",
@@ -3673,9 +4325,39 @@ dependencies = [
  "tracing-actix-web",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid 0.8.2",
  "venator",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3692,7 +4374,7 @@ dependencies = [
  "lazy_static",
  "log",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "rcgen",
  "regex",
  "ring",
@@ -3743,7 +4425,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "stun",
@@ -3776,7 +4458,7 @@ source = "git+https://github.com/MrCreativ3001/webrtc-rs.git?rev=c9675e222245e95
 dependencies = [
  "byteorder",
  "bytes",
- "rand",
+ "rand 0.9.2",
  "rtp",
  "thiserror 1.0.69",
 ]
@@ -3792,7 +4474,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -3833,7 +4515,7 @@ dependencies = [
  "log",
  "nix",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "thiserror 1.0.69",
  "tokio",
  "winapi",
@@ -3871,10 +4553,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4060,9 +4795,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4078,7 +4813,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4091,7 +4826,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -4110,7 +4845,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -4184,7 +4919,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4205,7 +4940,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4225,7 +4960,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4246,7 +4981,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4279,7 +5014,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ default-run = "web-server"
 moonlight-common = { workspace = true }
 common = { workspace = true }
 
-tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "fs", "sync", "macros"] }
 futures-concurrency = "7.7.1"
 
 clap = { workspace = true, features = ["derive", "env"] }
@@ -116,6 +116,9 @@ thiserror.workspace = true
 async-trait.workspace = true
 hex.workspace = true
 sha2 = "0.10.9"
+base64 = "0.22.1"
+url = "2.5.7"
+openidconnect = "4.0.1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It hosts a Web Server which will forward [Sunshine](https://docs.lizardbyte.dev/
   - [Configuring https](#configuring-https)
   - [Proxying via Apache 2](#proxying-via-apache-2)
   - [Authentication with a Reverse Proxy](#authentication-using-a-reverse-proxy)
+  - [Authentication with OpenID Connect](#authentication-with-openid-connect)
   - [Using Web Socket Transport](#using-websocket-transport)
 - [Config](#config)
 - [Migrating to v2](#migrating-to-v2)
@@ -234,6 +235,63 @@ By default the [auto create missing user](#forwarded-header-auto-create-missing-
     }
 }
 ```
+
+### Authentication with OpenID Connect
+Moonlight Web can optionally use app-native OpenID Connect authorization-code login with PKCE. Local username/password login remains available as a break-glass path and is not replaced by OIDC.
+
+OIDC is disabled unless `web_server.oidc` is configured. Moonlight binds OIDC accounts only to the verified immutable identity pair `{issuer_url, ID-token subject}`. The configured `username_claim` is used only as display/provisioning data for a new OIDC user; it is never used to link an OIDC login to an existing local password user or admin break-glass account. If a new OIDC identity would provision a username that already exists, login fails closed. Missing OIDC users are not created unless `auto_create_missing_user` is explicitly set to `true`.
+
+Keycloak example:
+```json
+{
+    "web_server": {
+        "url_path_prefix": "",
+        "session_cookie_secure": true,
+        "first_login_create_admin": false,
+        "oidc": {
+            "issuer_url": "https://keycloak.example.com/realms/moonlight",
+            "client_id": "moonlight-web",
+            "client_secret": "REPLACE_WITH_CLIENT_SECRET_IF_CONFIDENTIAL",
+            "redirect_url": "https://example.com/api/oidc/callback",
+            "scopes": ["openid", "profile", "email"],
+            "username_claim": "preferred_username",
+            "auto_create_missing_user": true,
+            "display_label": "OpenID Connect"
+        }
+    }
+}
+```
+
+If Moonlight Web is served under a path prefix, include that prefix in both values:
+```json
+{
+    "web_server": {
+        "url_path_prefix": "/moonlight",
+        "oidc": {
+            "issuer_url": "https://keycloak.example.com/realms/moonlight",
+            "client_id": "moonlight-web",
+            "redirect_url": "https://example.com/moonlight/api/oidc/callback"
+        }
+    }
+}
+```
+
+Keycloak client requirements:
+- Enable Standard flow.
+- Require or allow PKCE with method `S256`.
+- Set the exact redirect URI, for example `https://example.com/api/oidc/callback`.
+- Use a confidential client and `client_secret` if required by your deployment; public clients can omit `client_secret`.
+- Ensure the configured `username_claim` exists in the ID token. The default claim is `preferred_username`.
+- Treat the username claim as administrator-controlled and unique. It is display/provisioning data, not the immutable login identity.
+- Use the realm issuer URL as `issuer_url`, for example `https://keycloak.example.com/realms/moonlight`.
+
+Store `client_secret` only in an owner-readable runtime config or secret file. Do not commit real client secrets, authorization codes, tokens, state, nonce, or PKCE verifier values.
+
+Before enabling OIDC on a new instance, create and verify the local break-glass administrator, then set `first_login_create_admin` to `false`. Leaving its default value of `true` on an empty, publicly reachable instance allows the existing first-login endpoint to create the initial administrator. Set `auto_create_missing_user` to `true` only when Keycloak users should be provisioned automatically into the default non-admin role; its secure default is `false`.
+
+Pending OIDC login transactions are held in process memory for five minutes. A server restart interrupts in-flight logins, and multi-process deployments require sticky routing to the process that initiated the login.
+
+Logging out of Moonlight Web currently clears only the local Moonlight session. It does not end the upstream IdP session in Keycloak or another provider.
 
 ### Using WebSocket Transport
 
@@ -512,6 +570,33 @@ Automatically create a new user when the requested user specified in the [userna
     }
 }
 ```
+
+### OpenID Connect
+Optional app-native OpenID Connect login. Omit `oidc` to disable it.
+
+```json
+{
+    "web_server": {
+        "oidc": {
+            "issuer_url": "https://keycloak.example.com/realms/moonlight",
+            "client_id": "moonlight-web",
+            "redirect_url": "https://example.com/api/oidc/callback"
+        }
+    }
+}
+```
+
+Options:
+- `issuer_url`: OIDC issuer URL used for discovery.
+- `client_id`: OIDC client ID.
+- `client_secret`: optional secret for confidential clients.
+- `redirect_url`: exact callback URL registered with the provider.
+- `scopes`: defaults to `["openid", "profile", "email"]`.
+- `username_claim`: defaults to `preferred_username`.
+- `auto_create_missing_user`: defaults to `false`. When enabled, a missing OIDC identity is created with the default normal user role, no local password, and a stored issuer+subject binding.
+- `display_label`: defaults to `OpenID Connect` and is shown on the login button.
+
+Local password login is still available for administrators as a break-glass path. OIDC logins do not attach to existing local users by username, including admin users. SAML is not implemented by this native OIDC integration.
 
 ## Migrating to v2
 1. Some config options have changed so backup your old config by renaming it to something like `old_config.json`.

--- a/common/src/api_bindings.rs
+++ b/common/src/api_bindings.rs
@@ -25,6 +25,19 @@ pub struct PostLoginRequest {
     pub password: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, TS, Clone, PartialEq, Eq)]
+#[ts(export, export_to = EXPORT_PATH)]
+pub struct AuthMetadataResponse {
+    pub oidc: Option<OidcAuthMetadata>,
+}
+
+#[derive(Serialize, Deserialize, Debug, TS, Clone, PartialEq, Eq)]
+#[ts(export, export_to = EXPORT_PATH)]
+pub struct OidcAuthMetadata {
+    pub display_label: String,
+    pub login_url: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, TS, Clone, Copy)]
 #[ts(export, export_to = EXPORT_PATH)]
 pub enum HostState {

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -255,6 +255,8 @@ pub struct WebServerConfig {
     pub default_user_id: Option<u32>,
     pub default_role_id: Option<u32>,
     pub forwarded_header: Option<ForwardedHeaders>,
+    #[serde(default)]
+    pub oidc: Option<OidcConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -276,6 +278,7 @@ impl Default for WebServerConfig {
             default_user_id: None,
             default_role_id: None,
             forwarded_header: None,
+            oidc: None,
         }
     }
 }
@@ -310,6 +313,88 @@ impl Default for ForwardedHeaders {
 
 fn default_forwarded_headers_auto_create_user() -> bool {
     true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcConfig {
+    pub issuer_url: String,
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    pub redirect_url: String,
+    #[serde(default = "default_oidc_scopes")]
+    pub scopes: Vec<String>,
+    #[serde(default = "default_oidc_username_claim")]
+    pub username_claim: String,
+    #[serde(default)]
+    pub auto_create_missing_user: bool,
+    #[serde(default = "default_oidc_display_label")]
+    pub display_label: String,
+}
+
+fn default_oidc_scopes() -> Vec<String> {
+    vec![
+        "openid".to_string(),
+        "profile".to_string(),
+        "email".to_string(),
+    ]
+}
+
+fn default_oidc_username_claim() -> String {
+    "preferred_username".to_string()
+}
+
+fn default_oidc_display_label() -> String {
+    "OpenID Connect".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, OidcConfig};
+
+    #[test]
+    fn oidc_config_is_disabled_by_default() {
+        let config: Config = serde_json::from_str("{}").expect("default config should deserialize");
+
+        assert!(config.web_server.oidc.is_none());
+    }
+
+    #[test]
+    fn oidc_config_uses_secure_defaults_when_present() {
+        let oidc: OidcConfig = serde_json::from_str(
+            r#"{
+                "issuer_url": "https://idp.example.com/realms/moonlight",
+                "client_id": "moonlight-web",
+                "redirect_url": "https://example.com/api/oidc/callback"
+            }"#,
+        )
+        .expect("oidc config should deserialize");
+
+        assert_eq!(oidc.scopes, ["openid", "profile", "email"]);
+        assert_eq!(oidc.username_claim, "preferred_username");
+        assert!(!oidc.auto_create_missing_user);
+        assert_eq!(oidc.display_label, "OpenID Connect");
+        assert!(oidc.client_secret.is_none());
+    }
+
+    #[test]
+    fn oidc_config_serializes_defaults() {
+        let oidc = OidcConfig {
+            issuer_url: "https://idp.example.com/realms/moonlight".to_string(),
+            client_id: "moonlight-web".to_string(),
+            client_secret: None,
+            redirect_url: "https://example.com/api/oidc/callback".to_string(),
+            scopes: vec!["openid".to_string()],
+            username_claim: "sub".to_string(),
+            auto_create_missing_user: true,
+            display_label: "Company SSO".to_string(),
+        };
+
+        let json = serde_json::to_string(&oidc).expect("oidc config should serialize");
+
+        assert!(json.contains("\"issuer_url\""));
+        assert!(json.contains("\"display_label\":\"Company SSO\""));
+    }
 }
 
 // -- Moonlight

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "dev": "npm run generate-bindings && npm-watch build-light",
-    "build": "npm run generate-bindings && npm run build-light",
+    "build": "npm run test:oidc-login-order && npm run generate-bindings && npm run build-light",
+    "test:oidc-login-order": "node tests/oidc-login-order.test.mjs",
     "build-light": "tsc && npm run copy-static",
     "generate-bindings": "cargo test export_bindings --package common",
     "copy-static": "cpx \"web/**/*.{html,json,css,svg,png,js,wasm}\" dist/"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "dev": "npm run generate-bindings && npm-watch build-light",
-    "build": "npm run test:oidc-login-order && npm run generate-bindings && npm run build-light",
-    "test:oidc-login-order": "node tests/oidc-login-order.test.mjs",
+    "build": "npm run test:web && npm run generate-bindings && npm run build-light",
+    "test:web": "node tests/oidc-login-order.test.mjs && node tests/json-stream-buffer.test.mjs",
     "build-light": "tsc && npm run copy-static",
     "generate-bindings": "cargo test export_bindings --package common",
     "copy-static": "cpx \"web/**/*.{html,json,css,svg,png,js,wasm}\" dist/"

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -6,19 +6,27 @@ use actix_web::{
     get,
     middleware::Next,
     post,
-    web::{Data, Json},
+    web::{Data, Json, Query},
 };
-use common::api_bindings::PostLoginRequest;
+use common::api_bindings::{AuthMetadataResponse, OidcAuthMetadata, PostLoginRequest};
 use futures::future::{Ready, ready};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::{pin::Pin, time::Duration};
+use tracing::warn;
 
 use crate::app::{
     App, AppError,
     auth::{SessionToken, UserAuth},
+    oidc::{
+        OidcError, authorization_url, exchange_code_and_validate, login_path, username_from_claims,
+    },
     user::{Admin, AuthenticatedUser},
 };
 
 pub const COOKIE_SESSION_TOKEN_NAME: &str = "mlSession";
+const COOKIE_OIDC_STATE_NAME: &str = "mlOidcState";
+const OIDC_STATE_COOKIE_TTL: Duration = Duration::from_secs(5 * 60);
 
 impl FromRequest for UserAuth {
     type Error = AppError;
@@ -166,6 +174,193 @@ async fn logout(app: Data<App>, auth: UserAuth, req: HttpRequest) -> Result<Http
     Ok(response)
 }
 
+#[get("/auth/metadata")]
+async fn auth_metadata(app: Data<App>) -> HttpResponse {
+    let oidc = app
+        .config()
+        .web_server
+        .oidc
+        .as_ref()
+        .map(|config| OidcAuthMetadata {
+            display_label: config.display_label.clone(),
+            login_url: login_path(config, &app.config().web_server.url_path_prefix),
+        });
+
+    HttpResponse::Ok()
+        .append_header(("Cache-Control", "no-store"))
+        .json(AuthMetadataResponse { oidc })
+}
+
+#[derive(Debug, Deserialize)]
+struct OidcLoginQuery {
+    return_to: Option<String>,
+}
+
+#[get("/oidc/login")]
+async fn oidc_login(app: Data<App>, query: Query<OidcLoginQuery>) -> Result<HttpResponse, Error> {
+    let Some(config) = &app.config().web_server.oidc else {
+        return Ok(HttpResponse::NotFound()
+            .append_header(("Cache-Control", "no-store"))
+            .finish());
+    };
+
+    let start = app
+        .oidc_pending_logins()
+        .start(
+            query.return_to.as_deref(),
+            &app.config().web_server.url_path_prefix,
+        )
+        .await
+        .map_err(|err| match err {
+            OidcError::InvalidReturnTarget => {
+                warn!("OIDC login failed: invalid return target");
+                AppError::BadRequest
+            }
+            err => {
+                warn!("OIDC login failed: {err}");
+                AppError::BadRequest
+            }
+        })?;
+
+    let authorization_url = authorization_url(config, &start).await.map_err(|err| {
+        warn!("OIDC login failed: {err}");
+        AppError::BadRequest
+    })?;
+
+    Ok(HttpResponse::Found()
+        .cookie(build_oidc_state_cookie(&app, &start.state))
+        .append_header(("Cache-Control", "no-store"))
+        .append_header(("Location", authorization_url.to_string()))
+        .finish())
+}
+
+#[derive(Debug, Deserialize)]
+struct OidcCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[get("/oidc/callback")]
+async fn oidc_callback(
+    app: Data<App>,
+    req: HttpRequest,
+    query: Query<OidcCallbackQuery>,
+) -> Result<HttpResponse, Error> {
+    let Some(config) = &app.config().web_server.oidc else {
+        let mut response = HttpResponse::NotFound()
+            .append_header(("Cache-Control", "no-store"))
+            .finish();
+        response.add_removal_cookie(&build_oidc_state_cookie(&app, ""))?;
+        return Ok(response);
+    };
+
+    let Some(state) = query.state.as_deref() else {
+        warn!("OIDC callback failed: missing state");
+        return Ok(generic_oidc_bad_request(&app));
+    };
+    if !oidc_state_matches(&req, state) {
+        warn!("OIDC callback failed: state cookie mismatch");
+        return Ok(generic_oidc_bad_request(&app));
+    }
+
+    let pending = match app.oidc_pending_logins().take(state).await {
+        Ok(pending) => pending,
+        Err(_) => {
+            warn!("OIDC callback failed: pending state invalid or expired");
+            return Ok(generic_oidc_bad_request(&app));
+        }
+    };
+
+    if query.error.is_some() {
+        warn!("OIDC callback failed: provider returned an error");
+        return Ok(generic_oidc_bad_request(&app));
+    }
+    let _ = &query.error_description;
+
+    let Some(code) = query.code.clone() else {
+        warn!("OIDC callback failed: missing authorization code");
+        return Ok(generic_oidc_bad_request(&app));
+    };
+
+    let verified = match exchange_code_and_validate(config, code, pending.clone()).await {
+        Ok(claims) => claims,
+        Err(err) => {
+            warn!("OIDC callback failed: {err}");
+            return Ok(generic_oidc_bad_request(&app));
+        }
+    };
+    let username = match username_from_claims(&verified.claims, &config.username_claim) {
+        Ok(username) => username,
+        Err(err) => {
+            warn!("OIDC callback failed: {err}");
+            return Ok(generic_oidc_bad_request(&app));
+        }
+    };
+    let user = match app
+        .user_by_oidc_identity(verified.issuer, verified.subject, username)
+        .await
+    {
+        Ok(user) => user,
+        Err(err) => {
+            warn!("OIDC callback failed: {err}");
+            return Ok(generic_oidc_bad_request(&app));
+        }
+    };
+
+    let session_expiration = app.config().web_server.session_cookie_expiration;
+    let session = match user.new_session(session_expiration).await {
+        Ok(session) => session,
+        Err(err) => {
+            warn!("OIDC callback failed: session creation failed");
+            let _ = err;
+            return Ok(generic_oidc_bad_request(&app));
+        }
+    };
+    let mut session_bytes = [0; _];
+    let session_str = session.encode(&mut session_bytes);
+
+    let mut response = HttpResponse::Found()
+        .cookie(build_cookie(&app, session_expiration, session_str))
+        .append_header(("Cache-Control", "no-store"))
+        .append_header(("Location", pending.return_to))
+        .finish();
+    response.add_removal_cookie(&build_oidc_state_cookie(&app, ""))?;
+    Ok(response)
+}
+
+fn generic_oidc_bad_request(app: &App) -> HttpResponse {
+    let mut response = HttpResponse::BadRequest()
+        .append_header(("Cache-Control", "no-store"))
+        .body("OpenID Connect login failed");
+    let _ = response.add_removal_cookie(&build_oidc_state_cookie(app, ""));
+    response
+}
+
+fn oidc_state_matches(req: &HttpRequest, expected_state: &str) -> bool {
+    let Some(cookie) = req.cookie(COOKIE_OIDC_STATE_NAME) else {
+        return false;
+    };
+
+    Sha256::digest(cookie.value().as_bytes()) == Sha256::digest(expected_state.as_bytes())
+}
+
+fn build_oidc_state_cookie<'a>(app: &'a App, state: &'a str) -> Cookie<'a> {
+    Cookie::build(COOKIE_OIDC_STATE_NAME, state)
+        .path(format!(
+            "{}/api/oidc/callback",
+            app.config().web_server.url_path_prefix
+        ))
+        .same_site(SameSite::Lax)
+        .http_only(true)
+        .secure(app.config().web_server.session_cookie_secure)
+        .expires(Expiration::DateTime(
+            OffsetDateTime::now_utc() + OIDC_STATE_COOKIE_TTL,
+        ))
+        .finish()
+}
+
 pub async fn auth_middleware(
     req: ServiceRequest,
     next: Next<impl MessageBody>,
@@ -187,8 +382,13 @@ pub async fn auth_middleware(
 }
 
 pub fn build_cookie<'a>(app: &'a App, expiration: Duration, session_str: &'a str) -> Cookie<'a> {
+    let path = if app.config().web_server.url_path_prefix.is_empty() {
+        "/"
+    } else {
+        &app.config().web_server.url_path_prefix
+    };
     Cookie::build(COOKIE_SESSION_TOKEN_NAME, session_str)
-        .path(&app.config().web_server.url_path_prefix)
+        .path(path)
         .same_site(SameSite::Strict)
         .http_only(true) // not accessible via js
         .secure(app.config().web_server.session_cookie_secure)
@@ -199,4 +399,336 @@ pub fn build_cookie<'a>(app: &'a App, expiration: Duration, session_str: &'a str
 #[get("/authenticate")]
 async fn authenticate(_user: AuthenticatedUser) -> HttpResponse {
     HttpResponse::Ok().finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    use actix_web::{App as ActixApp, cookie::Cookie, http::StatusCode, test, web::Data};
+    use common::{
+        api_bindings::AuthMetadataResponse,
+        config::{Config, OidcConfig, StorageConfig},
+    };
+
+    use crate::{api::api_service, app::App};
+
+    use super::{COOKIE_OIDC_STATE_NAME, build_cookie};
+
+    fn has_oidc_state_removal_cookie(response: &actix_web::dev::ServiceResponse) -> bool {
+        response
+            .headers()
+            .get_all("Set-Cookie")
+            .filter_map(|value| value.to_str().ok())
+            .any(|value| {
+                value.starts_with(&format!("{COOKIE_OIDC_STATE_NAME}="))
+                    && value.contains("Max-Age=0")
+            })
+    }
+
+    fn test_config() -> Config {
+        let mut config = Config::default();
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        config.data_storage = StorageConfig::Json {
+            path: std::env::temp_dir()
+                .join(format!("moonlight-web-stream-oidc-auth-test-{suffix}.json"))
+                .display()
+                .to_string(),
+            session_expiration_check_interval: Duration::from_secs(60),
+        };
+        config.web_server.session_cookie_secure = true;
+        config
+    }
+
+    fn test_oidc_config() -> OidcConfig {
+        OidcConfig {
+            issuer_url: "https://idp.example.com/realms/moonlight".to_string(),
+            client_id: "moonlight-web".to_string(),
+            client_secret: None,
+            redirect_url: "https://example.com/api/oidc/callback".to_string(),
+            scopes: vec!["openid".to_string(), "profile".to_string()],
+            username_claim: "preferred_username".to_string(),
+            auto_create_missing_user: false,
+            display_label: "Company SSO".to_string(),
+        }
+    }
+
+    #[actix_web::test]
+    async fn session_cookie_path_defaults_to_root_and_honors_prefix() {
+        let app = App::new(test_config()).await.expect("app should start");
+        assert_eq!(
+            build_cookie(&app, Duration::from_secs(60), "session").path(),
+            Some("/")
+        );
+
+        let mut config = test_config();
+        config.web_server.url_path_prefix = "/moonlight".to_string();
+        let app = App::new(config).await.expect("app should start");
+        assert_eq!(
+            build_cookie(&app, Duration::from_secs(60), "session").path(),
+            Some("/moonlight")
+        );
+    }
+
+    #[actix_web::test]
+    async fn auth_metadata_hides_oidc_when_unconfigured() {
+        let app = App::new(test_config()).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/auth/metadata")
+            .to_request();
+        let response: AuthMetadataResponse = test::call_and_read_body_json(&service, request).await;
+
+        assert_eq!(response.oidc, None);
+    }
+
+    #[actix_web::test]
+    async fn auth_metadata_returns_oidc_label_and_login_url_when_configured() {
+        let mut config = test_config();
+        config.web_server.url_path_prefix = "/moonlight".to_string();
+        let mut oidc = test_oidc_config();
+        oidc.redirect_url = "https://example.com/moonlight/api/oidc/callback".to_string();
+        config.web_server.oidc = Some(oidc);
+        let app = App::new(config).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/auth/metadata")
+            .to_request();
+        let response = test::call_service(&service, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("Cache-Control")
+                .expect("cache-control header should be set"),
+            "no-store"
+        );
+        let response: AuthMetadataResponse = test::read_body_json(response).await;
+
+        let oidc = response.oidc.expect("oidc metadata should be present");
+        assert_eq!(oidc.display_label, "Company SSO");
+        assert_eq!(oidc.login_url, "/moonlight/api/oidc/login");
+    }
+
+    #[actix_web::test]
+    async fn oidc_login_rejects_invalid_return_target_before_discovery() {
+        let mut config = test_config();
+        config.web_server.url_path_prefix = "/moonlight".to_string();
+        let mut oidc = test_oidc_config();
+        oidc.redirect_url = "https://example.com/moonlight/api/oidc/callback".to_string();
+        config.web_server.oidc = Some(oidc);
+        let app = App::new(config).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/oidc/login?return_to=%2Fmoonlight-evil")
+            .to_request();
+        let response = test::call_service(&service, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn oidc_login_rejects_control_characters_in_return_target_before_discovery() {
+        let mut config = test_config();
+        config.web_server.oidc = Some(test_oidc_config());
+        let app = App::new(config).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/oidc/login?return_to=%2Fadmin.html%0A")
+            .to_request();
+        let response = test::call_service(&service, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn oidc_callback_rejects_provider_error_without_state() {
+        let mut config = test_config();
+        config.web_server.oidc = Some(test_oidc_config());
+        let app = App::new(config).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/oidc/callback?error=access_denied&error_description=secret")
+            .to_request();
+        let response = test::call_service(&service, request).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response
+                .headers()
+                .get("Cache-Control")
+                .expect("cache-control header should be set"),
+            "no-store"
+        );
+    }
+
+    #[actix_web::test]
+    async fn oidc_callback_removes_state_cookie_when_oidc_is_unconfigured() {
+        let app = App::new(test_config()).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let request = test::TestRequest::get()
+            .uri("/api/oidc/callback?state=state&code=code")
+            .cookie(Cookie::new(COOKIE_OIDC_STATE_NAME, "state"))
+            .to_request();
+        let response = test::call_service(&service, request).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(has_oidc_state_removal_cookie(&response));
+    }
+
+    #[actix_web::test]
+    async fn oidc_callback_rejects_missing_code_and_state() {
+        let mut config = test_config();
+        config.web_server.oidc = Some(test_oidc_config());
+        let app = App::new(config).await.expect("app should start");
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        let response = test::call_service(
+            &service,
+            test::TestRequest::get()
+                .uri("/api/oidc/callback")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = test::call_service(
+            &service,
+            test::TestRequest::get()
+                .uri("/api/oidc/callback?state=state")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn oidc_callback_rejects_invalid_expired_and_replayed_state() {
+        let mut config = test_config();
+        config.web_server.oidc = Some(test_oidc_config());
+        let app = App::new(config).await.expect("app should start");
+
+        app.oidc_pending_logins()
+            .insert_for_test(
+                "expired".to_string(),
+                "nonce".to_string(),
+                "verifier".to_string(),
+                "/".to_string(),
+                Instant::now() - Duration::from_secs(301),
+            )
+            .await;
+        app.oidc_pending_logins()
+            .insert_for_test(
+                "replayed".to_string(),
+                "nonce".to_string(),
+                "verifier".to_string(),
+                "/".to_string(),
+                Instant::now(),
+            )
+            .await;
+        app.oidc_pending_logins()
+            .take("replayed")
+            .await
+            .expect("test state should be consumed");
+
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        for state in ["missing", "expired", "replayed"] {
+            let request = test::TestRequest::get()
+                .uri(&format!("/api/oidc/callback?state={state}&code=code"))
+                .cookie(Cookie::new(COOKIE_OIDC_STATE_NAME, state))
+                .to_request();
+            let response = test::call_service(&service, request).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                response
+                    .headers()
+                    .get("Cache-Control")
+                    .expect("cache-control header should be set"),
+                "no-store"
+            );
+            assert!(has_oidc_state_removal_cookie(&response));
+        }
+    }
+
+    #[actix_web::test]
+    async fn oidc_callback_rejects_state_not_bound_to_browser_cookie() {
+        let mut config = test_config();
+        config.web_server.oidc = Some(test_oidc_config());
+        let app = App::new(config).await.expect("app should start");
+        app.oidc_pending_logins()
+            .insert_for_test(
+                "expected".to_string(),
+                "nonce".to_string(),
+                "verifier".to_string(),
+                "/".to_string(),
+                Instant::now(),
+            )
+            .await;
+        let service = test::init_service(
+            ActixApp::new()
+                .app_data(Data::new(app))
+                .service(api_service()),
+        )
+        .await;
+
+        for cookie_state in [None, Some("attacker-state")] {
+            let mut request =
+                test::TestRequest::get().uri("/api/oidc/callback?state=expected&code=code");
+            if let Some(cookie_state) = cookie_state {
+                request = request.cookie(Cookie::new(COOKIE_OIDC_STATE_NAME, cookie_state));
+            }
+            let response = test::call_service(&service, request.to_request()).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -31,7 +31,10 @@ pub fn api_service() -> impl HttpServiceFactory {
             // -- Auth
             auth::login,
             auth::logout,
-            auth::authenticate
+            auth::authenticate,
+            auth::auth_metadata,
+            auth::oidc_login,
+            auth::oidc_callback
         ])
         .service(services![
             // -- Host

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -63,6 +63,7 @@ pub async fn add_user(
                 password: Some(StoragePassword::new(&request.password)?),
                 role_id: RoleId(request.role_id),
                 client_unique_id: request.client_unique_id,
+                oidc_identity: None,
             },
         )
         .await?;
@@ -97,6 +98,7 @@ pub async fn patch_user(
                         password: new_password.map(Some),
                         role_id: request.role_id.map(RoleId),
                         client_unique_id: request.client_unique_id,
+                        oidc_identity: None,
                     },
                 )
                 .await?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,17 +18,19 @@ use tracing::{error, info, warn};
 use crate::app::{
     auth::{SessionToken, UserAuth},
     host::{AppId, HostId},
+    oidc::{OidcError, PendingOidcLogins, validate_oidc_startup_config},
     password::StoragePassword,
     role::{Role, RoleId},
     storage::{
-        Either, Storage, StorageHostModify, StorageRoleAdd, StorageRoleDefaultSettings,
-        StorageRolePermissions, StorageUserAdd, create_storage,
+        Either, Storage, StorageHostModify, StorageOidcIdentity, StorageRoleAdd,
+        StorageRoleDefaultSettings, StorageRolePermissions, StorageUserAdd, create_storage,
     },
     user::{Admin, AuthenticatedUser, RoleType, User, UserId},
 };
 
 pub mod auth;
 pub mod host;
+pub mod oidc;
 pub mod password;
 pub mod role;
 pub mod storage;
@@ -136,6 +138,7 @@ struct AppInner {
     config: Config,
     storage: Arc<dyn Storage + Send + Sync>,
     app_image_cache: RwLock<HashMap<(UserId, HostId, AppId), Bytes>>,
+    oidc_pending_logins: PendingOidcLogins,
 }
 
 pub type MoonlightClient = TokioHyperClient;
@@ -146,10 +149,13 @@ pub struct App {
 
 impl App {
     pub async fn new(config: Config) -> Result<Self, anyhow::Error> {
+        validate_oidc_startup_config(&config)?;
+
         let app = AppInner {
             storage: create_storage(config.data_storage.clone()).await?,
             config,
             app_image_cache: Default::default(),
+            oidc_pending_logins: Default::default(),
         };
 
         Ok(Self {
@@ -165,6 +171,10 @@ impl App {
 
     pub fn config(&self) -> &Config {
         &self.inner.config
+    }
+
+    pub fn oidc_pending_logins(&self) -> &PendingOidcLogins {
+        &self.inner.oidc_pending_logins
     }
 
     /// Handles all logic related to adding the first user:
@@ -192,6 +202,7 @@ impl App {
                 password: Some(StoragePassword::new(&password)?),
                 role_id: admin_role.id(),
                 client_unique_id: username,
+                oidc_identity: None,
             })
             .await?;
 
@@ -302,6 +313,7 @@ impl App {
                                 name: username.clone(),
                                 password: None,
                                 client_unique_id: username.clone(),
+                                oidc_identity: None,
                             })
                             .await?;
 
@@ -312,6 +324,85 @@ impl App {
 
                 user.authenticate(&auth).await
             }
+        }
+    }
+
+    pub async fn user_by_oidc_identity(
+        &self,
+        issuer: String,
+        subject: String,
+        username: String,
+    ) -> Result<AuthenticatedUser, OidcError> {
+        if issuer.is_empty() || subject.is_empty() {
+            return Err(OidcError::InvalidIdToken);
+        }
+        if username.is_empty() {
+            return Err(OidcError::MissingUsernameClaim);
+        }
+
+        let Some(config_oidc) = &self.config().web_server.oidc else {
+            return Err(OidcError::NotConfigured);
+        };
+
+        match self
+            .inner
+            .storage
+            .get_user_by_oidc_identity(&issuer, &subject)
+            .await
+        {
+            Ok((id, user)) => Ok(AuthenticatedUser {
+                inner: User {
+                    app: self.new_ref(),
+                    id,
+                    cache_storage: user.map(Arc::new),
+                },
+            }),
+            Err(AppError::UserNotFound) if config_oidc.auto_create_missing_user => {
+                if self.user_by_name(&username).await.is_ok() {
+                    return Err(OidcError::UsernameCollision);
+                }
+                let role = self
+                    .default_role()
+                    .await
+                    .map_err(|_| OidcError::MissingUser)?;
+                match self
+                    .add_user_no_auth(StorageUserAdd {
+                        role_id: role.id(),
+                        name: username.clone(),
+                        password: None,
+                        client_unique_id: username,
+                        oidc_identity: Some(StorageOidcIdentity {
+                            issuer: issuer.clone(),
+                            subject: subject.clone(),
+                        }),
+                    })
+                    .await
+                {
+                    Ok(user) => Ok(user),
+                    Err(AppError::UserAlreadyExists) => {
+                        // A concurrent callback for the same identity may have
+                        // provisioned the account after our initial lookup.
+                        match self
+                            .inner
+                            .storage
+                            .get_user_by_oidc_identity(&issuer, &subject)
+                            .await
+                        {
+                            Ok((id, user)) => Ok(AuthenticatedUser {
+                                inner: User {
+                                    app: self.new_ref(),
+                                    id,
+                                    cache_storage: user.map(Arc::new),
+                                },
+                            }),
+                            _ => Err(OidcError::UsernameCollision),
+                        }
+                    }
+                    Err(_) => Err(OidcError::MissingUser),
+                }
+            }
+            Err(AppError::UserNotFound) => Err(OidcError::MissingUser),
+            Err(_) => Err(OidcError::MissingUser),
         }
     }
 
@@ -533,5 +624,290 @@ impl App {
         };
 
         Ok(roles)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    use common::config::{Config, OidcConfig, StorageConfig};
+
+    use crate::app::{
+        App,
+        oidc::OidcError,
+        role::RoleId,
+        storage::{
+            StorageOidcIdentity, StorageRoleAdd, StorageRoleDefaultSettings,
+            StorageRolePermissions, StorageUserAdd,
+        },
+        user::RoleType,
+    };
+
+    fn test_config(auto_create_missing_user: bool) -> Config {
+        let mut config = Config::default();
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        config.data_storage = StorageConfig::Json {
+            path: std::env::temp_dir()
+                .join(format!("moonlight-web-stream-oidc-app-test-{suffix}.json"))
+                .display()
+                .to_string(),
+            session_expiration_check_interval: Duration::from_secs(60),
+        };
+        config.web_server.session_cookie_secure = true;
+        config.web_server.oidc = Some(OidcConfig {
+            issuer_url: "https://idp.example.com/realms/moonlight".to_string(),
+            client_id: "moonlight-web".to_string(),
+            client_secret: None,
+            redirect_url: "https://example.com/api/oidc/callback".to_string(),
+            scopes: vec!["openid".to_string(), "profile".to_string()],
+            username_claim: "preferred_username".to_string(),
+            auto_create_missing_user,
+            display_label: "OpenID Connect".to_string(),
+        });
+        config
+    }
+
+    #[actix_web::test]
+    async fn oidc_mapping_rejects_existing_local_user_with_same_username() {
+        let app = App::new(test_config(false))
+            .await
+            .expect("app should start");
+        let admin_role = app
+            .add_role_no_auth(StorageRoleAdd {
+                name: "Admin".to_string(),
+                ty: RoleType::Admin,
+                default_settings: StorageRoleDefaultSettings::default(),
+                permissions: StorageRolePermissions::default(),
+            })
+            .await
+            .expect("role should be created");
+        let _existing = app
+            .add_user_no_auth(StorageUserAdd {
+                role_id: admin_role.id(),
+                name: "alice".to_string(),
+                password: Some(
+                    crate::app::password::StoragePassword::new("password")
+                        .expect("password should hash"),
+                ),
+                client_unique_id: "alice".to_string(),
+                oidc_identity: None,
+            })
+            .await
+            .expect("user should be created");
+
+        let result = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "alice".to_string(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(OidcError::MissingUser)));
+    }
+
+    #[actix_web::test]
+    async fn oidc_mapping_rejects_missing_user_when_auto_create_disabled() {
+        let app = App::new(test_config(false))
+            .await
+            .expect("app should start");
+
+        let result = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "alice".to_string(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(OidcError::MissingUser)));
+    }
+
+    #[actix_web::test]
+    async fn oidc_mapping_auto_creates_default_role_user_with_identity_when_enabled() {
+        let mut config = test_config(true);
+        config.web_server.default_role_id = None;
+        let app = App::new(config).await.expect("app should start");
+
+        let mut mapped = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "alice".to_string(),
+            )
+            .await
+            .expect("missing user should be created");
+
+        let mapped_id = mapped.id();
+        assert_eq!(
+            mapped
+                .detailed_user()
+                .await
+                .expect("details should load")
+                .name,
+            "alice"
+        );
+        assert_ne!(mapped.role_id().await.expect("role should load"), RoleId(0));
+
+        let stored = app
+            .user_by_id(mapped_id)
+            .await
+            .expect("stored user should load");
+        let storage = app
+            .inner
+            .storage
+            .get_user(stored.id())
+            .await
+            .expect("storage user should load");
+        assert_eq!(
+            storage.oidc_identity,
+            Some(StorageOidcIdentity {
+                issuer: "https://idp.example.com/realms/moonlight".to_string(),
+                subject: "subject-1".to_string(),
+            })
+        );
+    }
+
+    #[actix_web::test]
+    async fn oidc_mapping_rejects_username_collision_between_subjects() {
+        let app = App::new(test_config(true)).await.expect("app should start");
+        let first = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "alice".to_string(),
+            )
+            .await
+            .expect("first subject should provision");
+
+        let second = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-2".to_string(),
+                "alice".to_string(),
+            )
+            .await;
+
+        assert!(matches!(second, Err(OidcError::UsernameCollision)));
+        assert_eq!(
+            first.id(),
+            app.user_by_name("alice")
+                .await
+                .expect("alice should still resolve by local username")
+                .id()
+        );
+    }
+
+    #[actix_web::test]
+    async fn oidc_mapping_reuses_identity_when_username_claim_changes() {
+        let app = App::new(test_config(true)).await.expect("app should start");
+        let first = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "alice".to_string(),
+            )
+            .await
+            .expect("first login should provision");
+        let second = app
+            .user_by_oidc_identity(
+                "https://idp.example.com/realms/moonlight".to_string(),
+                "subject-1".to_string(),
+                "renamed-alice".to_string(),
+            )
+            .await
+            .expect("same identity should map");
+
+        assert_eq!(first.id(), second.id());
+    }
+
+    #[actix_web::test]
+    async fn concurrent_oidc_provisioning_reuses_one_identity() {
+        let app = App::new(test_config(true)).await.expect("app should start");
+
+        let first = app.user_by_oidc_identity(
+            "https://idp.example.com/realms/moonlight".to_string(),
+            "subject-concurrent".to_string(),
+            "concurrent-alice".to_string(),
+        );
+        let second = app.user_by_oidc_identity(
+            "https://idp.example.com/realms/moonlight".to_string(),
+            "subject-concurrent".to_string(),
+            "concurrent-alice".to_string(),
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        let first = first.expect("first callback should resolve");
+        let second = second.expect("concurrent callback should resolve");
+        assert_eq!(first.id(), second.id());
+    }
+
+    #[actix_web::test]
+    async fn old_json_without_oidc_identity_loads() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "moonlight-web-stream-oidc-old-json-test-{suffix}.json"
+        ));
+        fs::write(
+            &path,
+            r#"{
+                "version": "3",
+                "users": {
+                    "1": {
+                        "role_id": 1,
+                        "name": "alice",
+                        "password": null,
+                        "client_unique_id": "alice"
+                    }
+                },
+                "hosts": {},
+                "roles": {
+                    "1": {
+                        "name": "User",
+                        "ty": "User",
+                        "default_settings": {},
+                        "permissions": {
+                            "allow_add_hosts": true,
+                            "maximum_bitrate_kbps": null,
+                            "allow_codec_h264": true,
+                            "allow_codec_h265": true,
+                            "allow_codec_av1": true,
+                            "allow_hdr": true,
+                            "allow_transport_webrtc": true,
+                            "allow_transport_websockets": true
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("old json should be written");
+
+        let mut config = test_config(false);
+        config.data_storage = StorageConfig::Json {
+            path: path.display().to_string(),
+            session_expiration_check_interval: Duration::from_secs(60),
+        };
+        let app = App::new(config).await.expect("old json should load");
+        let storage = app
+            .inner
+            .storage
+            .get_user_by_name("alice")
+            .await
+            .expect("old user should load")
+            .1
+            .expect("old user should be returned");
+
+        assert_eq!(storage.oidc_identity, None);
+        let _ = fs::remove_file(path);
     }
 }

--- a/src/app/oidc.rs
+++ b/src/app/oidc.rs
@@ -1,0 +1,926 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use common::config::OidcConfig;
+use openidconnect::{
+    AccessTokenHash, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointMaybeSet,
+    EndpointNotSet, EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse, PkceCodeChallenge,
+    PkceCodeVerifier, RedirectUrl, Scope, TokenResponse,
+    core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata},
+    reqwest,
+};
+use openssl::rand::rand_bytes;
+use serde_json::Value;
+use thiserror::Error;
+use tokio::sync::Mutex;
+use url::Url;
+
+const OIDC_RANDOM_BYTES: usize = 32;
+const PENDING_LOGIN_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_PENDING_LOGINS: usize = 1024;
+
+type DiscoveredCoreClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum OidcError {
+    #[error("openid connect login is not configured")]
+    NotConfigured,
+    #[error("openid connect login state is invalid")]
+    InvalidState,
+    #[error("openid connect login state expired")]
+    ExpiredState,
+    #[error("openid connect username claim is missing or invalid")]
+    MissingUsernameClaim,
+    #[error("openid connect user does not exist")]
+    MissingUser,
+    #[error("openid connect username is already owned by another login method or identity")]
+    UsernameCollision,
+    #[error("openid connect return target is invalid")]
+    InvalidReturnTarget,
+    #[error("openid connect provider request failed")]
+    ProviderRequest,
+    #[error("openid connect token response is invalid")]
+    InvalidTokenResponse,
+    #[error("openid connect id token is missing")]
+    MissingIdToken,
+    #[error("openid connect id token is invalid")]
+    InvalidIdToken,
+    #[error("openid connect access token hash is invalid")]
+    InvalidAccessTokenHash,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingOidcLogin {
+    pub nonce: String,
+    pub code_verifier: String,
+    pub return_to: String,
+    created_at: Instant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OidcAuthorizationStart {
+    pub state: String,
+    pub nonce: String,
+    pub code_verifier: String,
+    pub return_to: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedOidcClaims {
+    pub issuer: String,
+    pub subject: String,
+    pub claims: Value,
+}
+
+#[derive(Default)]
+pub struct PendingOidcLogins {
+    states: Mutex<HashMap<String, PendingOidcLogin>>,
+}
+
+impl PendingOidcLogins {
+    pub async fn start(
+        &self,
+        return_to: Option<&str>,
+        path_prefix: &str,
+    ) -> Result<OidcAuthorizationStart, OidcError> {
+        self.prune_expired(Instant::now()).await;
+
+        let state = random_urlsafe().map_err(|_| OidcError::InvalidState)?;
+        let nonce = random_urlsafe().map_err(|_| OidcError::InvalidState)?;
+        let code_verifier = random_urlsafe().map_err(|_| OidcError::InvalidState)?;
+        let return_to = validated_return_target(return_to, path_prefix)?;
+
+        let login = PendingOidcLogin {
+            nonce: nonce.clone(),
+            code_verifier: code_verifier.clone(),
+            return_to: return_to.clone(),
+            created_at: Instant::now(),
+        };
+
+        let mut states = self.states.lock().await;
+        if states.len() >= MAX_PENDING_LOGINS
+            && let Some(oldest_state) = states
+                .iter()
+                .min_by_key(|(_, login)| login.created_at)
+                .map(|(state, _)| state.clone())
+        {
+            states.remove(&oldest_state);
+        }
+        states.insert(state.clone(), login);
+
+        Ok(OidcAuthorizationStart {
+            state,
+            nonce,
+            code_verifier,
+            return_to,
+        })
+    }
+
+    pub async fn take(&self, state: &str) -> Result<PendingOidcLogin, OidcError> {
+        let Some(login) = self.states.lock().await.remove(state) else {
+            return Err(OidcError::InvalidState);
+        };
+
+        if login.created_at.elapsed() > PENDING_LOGIN_TTL {
+            return Err(OidcError::ExpiredState);
+        }
+
+        Ok(login)
+    }
+
+    async fn prune_expired(&self, now: Instant) {
+        self.states
+            .lock()
+            .await
+            .retain(|_, login| now.duration_since(login.created_at) <= PENDING_LOGIN_TTL);
+    }
+
+    #[cfg(test)]
+    pub async fn insert_for_test(
+        &self,
+        state: String,
+        nonce: String,
+        code_verifier: String,
+        return_to: String,
+        created_at: Instant,
+    ) {
+        self.states.lock().await.insert(
+            state,
+            PendingOidcLogin {
+                nonce,
+                code_verifier,
+                return_to,
+                created_at,
+            },
+        );
+    }
+
+    #[cfg(test)]
+    pub async fn len_for_test(&self) -> usize {
+        self.states.lock().await.len()
+    }
+}
+
+pub fn username_from_claims(claims: &Value, username_claim: &str) -> Result<String, OidcError> {
+    let Some(username) = claims.get(username_claim).and_then(Value::as_str) else {
+        return Err(OidcError::MissingUsernameClaim);
+    };
+    let username = username.trim();
+    if username.is_empty() {
+        return Err(OidcError::MissingUsernameClaim);
+    }
+    Ok(username.to_string())
+}
+
+pub fn validated_return_target(
+    return_to: Option<&str>,
+    path_prefix: &str,
+) -> Result<String, OidcError> {
+    let default_target = if path_prefix.is_empty() {
+        "/".to_string()
+    } else {
+        path_prefix.to_string()
+    };
+
+    let Some(return_to) = return_to else {
+        return Ok(default_target);
+    };
+
+    if return_to.is_empty() {
+        return Ok(default_target);
+    }
+
+    if return_to.chars().any(char::is_control)
+        || Url::parse(return_to).is_ok()
+        || return_to.starts_with("//")
+        || !return_to.starts_with('/')
+        || return_to.contains('\\')
+    {
+        return Err(OidcError::InvalidReturnTarget);
+    }
+
+    if path_prefix.is_empty()
+        || return_to == path_prefix
+        || return_to
+            .strip_prefix(path_prefix)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    {
+        Ok(return_to.to_string())
+    } else {
+        Err(OidcError::InvalidReturnTarget)
+    }
+}
+
+pub fn login_path(config: &OidcConfig, path_prefix: &str) -> String {
+    let _ = config;
+    format!("{path_prefix}/api/oidc/login")
+}
+
+pub async fn authorization_url(
+    config: &OidcConfig,
+    start: &OidcAuthorizationStart,
+) -> Result<Url, OidcError> {
+    let client = discover_client(config).await?;
+    let code_verifier = PkceCodeVerifier::new(start.code_verifier.clone());
+    let code_challenge = PkceCodeChallenge::from_code_verifier_sha256(&code_verifier);
+
+    let state = start.state.clone();
+    let nonce = start.nonce.clone();
+    let mut request = client
+        .authorize_url(
+            CoreAuthenticationFlow::AuthorizationCode,
+            move || CsrfToken::new(state),
+            move || Nonce::new(nonce),
+        )
+        .set_pkce_challenge(code_challenge)
+        .add_scope(Scope::new("openid".to_string()));
+
+    for scope in config
+        .scopes
+        .iter()
+        .filter(|scope| scope.as_str() != "openid")
+    {
+        request = request.add_scope(Scope::new(scope.clone()));
+    }
+
+    let (url, _, _) = request.url();
+    Ok(url)
+}
+
+pub async fn exchange_code_and_validate(
+    config: &OidcConfig,
+    code: String,
+    pending: PendingOidcLogin,
+) -> Result<VerifiedOidcClaims, OidcError> {
+    let http_client = oidc_http_client()?;
+    let client = discover_client_with_http(config, &http_client).await?;
+
+    let token_response = client
+        .exchange_code(AuthorizationCode::new(code))
+        .map_err(|_| OidcError::ProviderRequest)?
+        .set_pkce_verifier(PkceCodeVerifier::new(pending.code_verifier))
+        .request_async(&http_client)
+        .await
+        .map_err(|_| OidcError::ProviderRequest)?;
+
+    let id_token = token_response.id_token().ok_or(OidcError::MissingIdToken)?;
+    let verifier = client.id_token_verifier();
+    let claims = id_token
+        .claims(&verifier, &Nonce::new(pending.nonce))
+        .map_err(|_| OidcError::InvalidIdToken)?;
+
+    if let Some(expected_access_token_hash) = claims.access_token_hash() {
+        let actual_access_token_hash = AccessTokenHash::from_token(
+            token_response.access_token(),
+            id_token
+                .signing_alg()
+                .map_err(|_| OidcError::InvalidIdToken)?,
+            id_token
+                .signing_key(&verifier)
+                .map_err(|_| OidcError::InvalidIdToken)?,
+        )
+        .map_err(|_| OidcError::InvalidAccessTokenHash)?;
+
+        if actual_access_token_hash != *expected_access_token_hash {
+            return Err(OidcError::InvalidAccessTokenHash);
+        }
+    }
+
+    let claims = serde_json::to_value(claims).map_err(|_| OidcError::InvalidTokenResponse)?;
+    let issuer = claims
+        .get("iss")
+        .and_then(Value::as_str)
+        .ok_or(OidcError::InvalidIdToken)?
+        .to_string();
+    let subject = claims
+        .get("sub")
+        .and_then(Value::as_str)
+        .ok_or(OidcError::InvalidIdToken)?
+        .to_string();
+
+    Ok(VerifiedOidcClaims {
+        issuer,
+        subject,
+        claims,
+    })
+}
+
+async fn discover_client(config: &OidcConfig) -> Result<DiscoveredCoreClient, OidcError> {
+    let http_client = oidc_http_client()?;
+    discover_client_with_http(config, &http_client).await
+}
+
+async fn discover_client_with_http(
+    config: &OidcConfig,
+    http_client: &reqwest::Client,
+) -> Result<DiscoveredCoreClient, OidcError> {
+    let provider_metadata = CoreProviderMetadata::discover_async(
+        IssuerUrl::new(config.issuer_url.clone()).map_err(|_| OidcError::ProviderRequest)?,
+        http_client,
+    )
+    .await
+    .map_err(|_| OidcError::ProviderRequest)?;
+
+    let client_secret = config.client_secret.clone().map(ClientSecret::new);
+    Ok(CoreClient::from_provider_metadata(
+        provider_metadata,
+        ClientId::new(config.client_id.clone()),
+        client_secret,
+    )
+    .set_redirect_uri(
+        RedirectUrl::new(config.redirect_url.clone()).map_err(|_| OidcError::ProviderRequest)?,
+    ))
+}
+
+fn oidc_http_client() -> Result<reqwest::Client, OidcError> {
+    reqwest::ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|_| OidcError::ProviderRequest)
+}
+
+pub fn validate_oidc_startup_config(config: &common::config::Config) -> Result<(), anyhow::Error> {
+    let Some(oidc) = &config.web_server.oidc else {
+        return Ok(());
+    };
+
+    let issuer = Url::parse(&oidc.issuer_url)
+        .map_err(|err| anyhow::anyhow!("invalid OIDC issuer_url: {err}"))?;
+    match issuer.scheme() {
+        "https" => {}
+        "http" if issuer.host_str().is_some_and(is_loopback_host) => {}
+        _ => {
+            return Err(anyhow::anyhow!(
+                "invalid OIDC issuer_url: issuer must use HTTPS unless it is a loopback development issuer"
+            ));
+        }
+    }
+
+    let redirect = Url::parse(&oidc.redirect_url)
+        .map_err(|err| anyhow::anyhow!("invalid OIDC redirect_url: {err}"))?;
+    if redirect.scheme() != "https" {
+        return Err(anyhow::anyhow!(
+            "invalid OIDC redirect_url: redirect URL must use HTTPS"
+        ));
+    }
+
+    let expected_path = format!("{}/api/oidc/callback", config.web_server.url_path_prefix);
+    if redirect.path() != expected_path {
+        return Err(anyhow::anyhow!(
+            "invalid OIDC redirect_url: path must be {expected_path:?}"
+        ));
+    }
+
+    if !config.web_server.session_cookie_secure {
+        return Err(anyhow::anyhow!(
+            "invalid OIDC configuration: session_cookie_secure must be true when OIDC is enabled"
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback())
+}
+
+fn random_urlsafe() -> Result<String, openssl::error::ErrorStack> {
+    let mut bytes = [0; OIDC_RANDOM_BYTES];
+    rand_bytes(&mut bytes)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        net::TcpListener,
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    };
+
+    use actix_web::{App as ActixApp, HttpResponse, HttpServer, web};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use common::config::OidcConfig;
+    use openssl::{
+        hash::MessageDigest,
+        pkey::{PKey, Private},
+        rsa::Rsa,
+        sign::Signer,
+    };
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+
+    use super::{
+        MAX_PENDING_LOGINS, OidcError, PendingOidcLogin, PendingOidcLogins, authorization_url,
+        exchange_code_and_validate, username_from_claims, validate_oidc_startup_config,
+        validated_return_target,
+    };
+
+    fn rs256_id_token(
+        issuer: &str,
+        client_id: &str,
+        signing_key: &PKey<Private>,
+        nonce: &str,
+        subject: &str,
+        access_token: &str,
+        expires_in: i64,
+    ) -> String {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_secs();
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256","kid":"test-key","typ":"JWT"}"#);
+        let access_token_hash = Sha256::digest(access_token.as_bytes());
+        let at_hash = URL_SAFE_NO_PAD.encode(&access_token_hash[..16]);
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&json!({
+                "iss": issuer,
+                "sub": subject,
+                "aud": client_id,
+                "exp": (now as i64 + expires_in) as u64,
+                "iat": now,
+                "nonce": nonce,
+                "at_hash": at_hash
+            }))
+            .expect("claims should serialize"),
+        );
+        let signing_input = format!("{header}.{payload}");
+        let mut signer =
+            Signer::new(MessageDigest::sha256(), signing_key).expect("RSA signer should build");
+        signer
+            .update(signing_input.as_bytes())
+            .expect("RSA input should be accepted");
+        let signature = signer.sign_to_vec().expect("RSA key should sign");
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature))
+    }
+
+    #[actix_web::test]
+    async fn authorization_url_uses_discovery_state_nonce_and_pkce() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
+        let issuer = format!(
+            "http://{}",
+            listener.local_addr().expect("listener should have address")
+        );
+        let provider_issuer = issuer.clone();
+        let server = HttpServer::new(move || {
+            let metadata_issuer = provider_issuer.clone();
+            ActixApp::new()
+                .route(
+                    "/.well-known/openid-configuration",
+                    web::get().to(move || {
+                        let issuer = metadata_issuer.clone();
+                        async move {
+                            HttpResponse::Ok().json(json!({
+                                "issuer": issuer,
+                                "authorization_endpoint": format!("{issuer}/authorize"),
+                                "token_endpoint": format!("{issuer}/token"),
+                                "jwks_uri": format!("{issuer}/jwks"),
+                                "response_types_supported": ["code"],
+                                "subject_types_supported": ["public"],
+                                "id_token_signing_alg_values_supported": ["RS256"],
+                                "token_endpoint_auth_methods_supported": ["none"]
+                            }))
+                        }
+                    }),
+                )
+                .route(
+                    "/jwks",
+                    web::get().to(|| async { HttpResponse::Ok().json(json!({"keys": []})) }),
+                )
+        })
+        .listen(listener)
+        .expect("test provider should listen")
+        .run();
+        let handle = server.handle();
+        actix_web::rt::spawn(server);
+
+        let config = OidcConfig {
+            issuer_url: issuer.clone(),
+            client_id: "moonlight-web".to_string(),
+            client_secret: None,
+            redirect_url: "https://stream.example/api/oidc/callback".to_string(),
+            scopes: vec!["profile".to_string()],
+            username_claim: "preferred_username".to_string(),
+            auto_create_missing_user: false,
+            display_label: "SSO".to_string(),
+        };
+        let pending = PendingOidcLogins::default();
+        let start = pending
+            .start(Some("/admin.html"), "")
+            .await
+            .expect("pending login should start");
+
+        let url = authorization_url(&config, &start)
+            .await
+            .expect("authorization URL should be built");
+        let query: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+
+        let expected_authorize_endpoint = format!("{issuer}/authorize");
+        assert_eq!(
+            url.as_str().split('?').next(),
+            Some(expected_authorize_endpoint.as_str())
+        );
+        assert_eq!(query.get("client_id"), Some(&"moonlight-web".to_string()));
+        assert_eq!(query.get("response_type"), Some(&"code".to_string()));
+        assert_eq!(query.get("redirect_uri"), Some(&config.redirect_url));
+        assert_eq!(query.get("state"), Some(&start.state));
+        assert_eq!(query.get("nonce"), Some(&start.nonce));
+        assert_eq!(
+            query.get("code_challenge_method"),
+            Some(&"S256".to_string())
+        );
+        assert!(
+            query
+                .get("code_challenge")
+                .is_some_and(|value| !value.is_empty())
+        );
+        let scope = query.get("scope").expect("scope should be present");
+        assert!(scope.split_whitespace().any(|scope| scope == "openid"));
+        assert!(scope.split_whitespace().any(|scope| scope == "profile"));
+
+        handle.stop(true).await;
+    }
+
+    #[actix_web::test]
+    async fn token_exchange_cryptographically_validates_id_token_and_nonce() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
+        let issuer = format!(
+            "http://{}",
+            listener.local_addr().expect("listener should have address")
+        );
+        let client_id = "moonlight-web".to_string();
+        let rsa = Rsa::generate(2048).expect("test RSA key should generate");
+        let jwk = json!({
+            "kty": "RSA",
+            "use": "sig",
+            "kid": "test-key",
+            "alg": "RS256",
+            "n": URL_SAFE_NO_PAD.encode(rsa.n().to_vec()),
+            "e": URL_SAFE_NO_PAD.encode(rsa.e().to_vec())
+        });
+        let signing_key = PKey::from_rsa(rsa).expect("test RSA key should import");
+        let provider_issuer = issuer.clone();
+        let provider_client_id = client_id.clone();
+        let provider_jwk = jwk.clone();
+        let provider_signing_key = signing_key.clone();
+        let server = HttpServer::new(move || {
+            let metadata_issuer = provider_issuer.clone();
+            let token_issuer = provider_issuer.clone();
+            let token_client_id = provider_client_id.clone();
+            let jwk = provider_jwk.clone();
+            let token_signing_key = provider_signing_key.clone();
+            ActixApp::new()
+                .route(
+                    "/.well-known/openid-configuration",
+                    web::get().to(move || {
+                        let issuer = metadata_issuer.clone();
+                        async move {
+                            HttpResponse::Ok().json(json!({
+                                "issuer": issuer,
+                                "authorization_endpoint": format!("{issuer}/authorize"),
+                                "token_endpoint": format!("{issuer}/token"),
+                                "jwks_uri": format!("{issuer}/jwks"),
+                                "response_types_supported": ["code"],
+                                "subject_types_supported": ["public"],
+                                "id_token_signing_alg_values_supported": ["RS256"],
+                                "token_endpoint_auth_methods_supported": ["none"]
+                            }))
+                        }
+                    }),
+                )
+                .route(
+                    "/jwks",
+                    web::get().to(move || {
+                        let jwk = jwk.clone();
+                        async move { HttpResponse::Ok().json(json!({"keys": [jwk]})) }
+                    }),
+                )
+                .route(
+                    "/token",
+                    web::post().to(move |form: web::Form<HashMap<String, String>>| {
+                        let code = form.get("code").map(String::as_str).unwrap_or_default();
+                        let (issuer, client_id, nonce, access_token, expires_in) = match code {
+                            "wrong-issuer" => (
+                                format!("{token_issuer}/other"),
+                                token_client_id.clone(),
+                                "expected-nonce",
+                                "access-token",
+                                300,
+                            ),
+                            "wrong-audience" => (
+                                token_issuer.clone(),
+                                "other-client".to_string(),
+                                "expected-nonce",
+                                "access-token",
+                                300,
+                            ),
+                            "wrong-at-hash" => (
+                                token_issuer.clone(),
+                                token_client_id.clone(),
+                                "expected-nonce",
+                                "different-access-token",
+                                300,
+                            ),
+                            "expired" => (
+                                token_issuer.clone(),
+                                token_client_id.clone(),
+                                "expected-nonce",
+                                "access-token",
+                                -300,
+                            ),
+                            _ => (
+                                token_issuer.clone(),
+                                token_client_id.clone(),
+                                "expected-nonce",
+                                "access-token",
+                                300,
+                            ),
+                        };
+                        let id_token = rs256_id_token(
+                            &issuer,
+                            &client_id,
+                            &token_signing_key,
+                            nonce,
+                            "alice-subject",
+                            access_token,
+                            expires_in,
+                        );
+                        async move {
+                            HttpResponse::Ok().json(json!({
+                                "access_token": "access-token",
+                                "token_type": "Bearer",
+                                "expires_in": 300,
+                                "id_token": id_token
+                            }))
+                        }
+                    }),
+                )
+        })
+        .listen(listener)
+        .expect("test provider should listen")
+        .run();
+        let handle = server.handle();
+        actix_web::rt::spawn(server);
+
+        let config = OidcConfig {
+            issuer_url: issuer,
+            client_id,
+            client_secret: None,
+            redirect_url: "https://stream.example/api/oidc/callback".to_string(),
+            scopes: vec!["openid".to_string()],
+            username_claim: "sub".to_string(),
+            auto_create_missing_user: false,
+            display_label: "SSO".to_string(),
+        };
+        let valid_pending = PendingOidcLogin {
+            nonce: "expected-nonce".to_string(),
+            code_verifier: "0123456789abcdef0123456789abcdef0123456789abc".to_string(),
+            return_to: "/".to_string(),
+            created_at: Instant::now(),
+        };
+        let claims = exchange_code_and_validate(&config, "valid-code".to_string(), valid_pending)
+            .await
+            .expect("valid signed ID token should pass");
+        assert_eq!(claims.issuer, config.issuer_url);
+        assert_eq!(claims.subject, "alice-subject");
+        assert_eq!(
+            claims.claims.get("sub").and_then(|value| value.as_str()),
+            Some("alice-subject")
+        );
+
+        let invalid_nonce = PendingOidcLogin {
+            nonce: "different-nonce".to_string(),
+            code_verifier: "0123456789abcdef0123456789abcdef0123456789abc".to_string(),
+            return_to: "/".to_string(),
+            created_at: Instant::now(),
+        };
+        assert!(matches!(
+            exchange_code_and_validate(&config, "valid-code".to_string(), invalid_nonce).await,
+            Err(OidcError::InvalidIdToken)
+        ));
+
+        for (code, expected_error) in [
+            ("wrong-at-hash", OidcError::InvalidAccessTokenHash),
+            ("wrong-issuer", OidcError::InvalidIdToken),
+            ("wrong-audience", OidcError::InvalidIdToken),
+            ("expired", OidcError::InvalidIdToken),
+        ] {
+            let pending = PendingOidcLogin {
+                nonce: "expected-nonce".to_string(),
+                code_verifier: "0123456789abcdef0123456789abcdef0123456789abc".to_string(),
+                return_to: "/".to_string(),
+                created_at: Instant::now(),
+            };
+            assert_eq!(
+                exchange_code_and_validate(&config, code.to_string(), pending).await,
+                Err(expected_error)
+            );
+        }
+
+        handle.stop(true).await;
+    }
+
+    #[tokio::test]
+    async fn pending_oidc_state_is_one_time() {
+        let pending = PendingOidcLogins::default();
+        let start = pending
+            .start(Some("/app"), "")
+            .await
+            .expect("state should be created");
+
+        let login = pending
+            .take(&start.state)
+            .await
+            .expect("first use should succeed");
+        assert_eq!(login.nonce, start.nonce);
+        assert_eq!(login.code_verifier, start.code_verifier);
+        assert_eq!(login.return_to, "/app");
+
+        let replay = pending.take(&start.state).await;
+        assert!(matches!(replay, Err(OidcError::InvalidState)));
+    }
+
+    #[tokio::test]
+    async fn pending_oidc_state_evicts_oldest_when_full() {
+        let pending = PendingOidcLogins::default();
+        let oldest = Instant::now() - Duration::from_secs(60);
+        pending
+            .insert_for_test(
+                "oldest".to_string(),
+                "nonce".to_string(),
+                "verifier".to_string(),
+                "/".to_string(),
+                oldest,
+            )
+            .await;
+        for index in 1..MAX_PENDING_LOGINS {
+            pending
+                .insert_for_test(
+                    format!("state-{index}"),
+                    "nonce".to_string(),
+                    "verifier".to_string(),
+                    "/".to_string(),
+                    Instant::now(),
+                )
+                .await;
+        }
+
+        pending
+            .start(Some("/app"), "")
+            .await
+            .expect("new state should evict oldest instead of failing");
+
+        assert_eq!(pending.len_for_test().await, MAX_PENDING_LOGINS);
+        assert!(matches!(
+            pending.take("oldest").await,
+            Err(OidcError::InvalidState)
+        ));
+    }
+
+    #[tokio::test]
+    async fn pending_oidc_state_expires() {
+        let pending = PendingOidcLogins::default();
+        pending
+            .insert_for_test(
+                "state".to_string(),
+                "nonce".to_string(),
+                "verifier".to_string(),
+                "/".to_string(),
+                Instant::now() - Duration::from_secs(301),
+            )
+            .await;
+
+        let result = pending.take("state").await;
+        assert!(matches!(result, Err(OidcError::ExpiredState)));
+    }
+
+    #[test]
+    fn username_claim_must_exist_and_be_non_empty_string() {
+        assert_eq!(
+            username_from_claims(
+                &json!({"preferred_username": "alice"}),
+                "preferred_username"
+            ),
+            Ok("alice".to_string())
+        );
+        assert_eq!(
+            username_from_claims(&json!({"preferred_username": ""}), "preferred_username"),
+            Err(OidcError::MissingUsernameClaim)
+        );
+        assert_eq!(
+            username_from_claims(&json!({"preferred_username": 123}), "preferred_username"),
+            Err(OidcError::MissingUsernameClaim)
+        );
+        assert_eq!(
+            username_from_claims(&json!({"sub": "alice"}), "preferred_username"),
+            Err(OidcError::MissingUsernameClaim)
+        );
+    }
+
+    #[test]
+    fn return_target_rejects_open_redirects() {
+        assert_eq!(
+            validated_return_target(None, "/moonlight"),
+            Ok("/moonlight".to_string())
+        );
+        assert_eq!(
+            validated_return_target(Some("/moonlight/admin.html"), "/moonlight"),
+            Ok("/moonlight/admin.html".to_string())
+        );
+        assert_eq!(
+            validated_return_target(Some("/moonlight-evil"), "/moonlight"),
+            Err(OidcError::InvalidReturnTarget)
+        );
+        assert_eq!(
+            validated_return_target(Some("https://evil.example"), "/moonlight"),
+            Err(OidcError::InvalidReturnTarget)
+        );
+        assert_eq!(
+            validated_return_target(Some("//evil.example"), "/moonlight"),
+            Err(OidcError::InvalidReturnTarget)
+        );
+        assert_eq!(
+            validated_return_target(Some("/other"), "/moonlight"),
+            Err(OidcError::InvalidReturnTarget)
+        );
+        assert_eq!(
+            validated_return_target(Some("/moonlight/admin.html\n"), "/moonlight"),
+            Err(OidcError::InvalidReturnTarget)
+        );
+    }
+
+    #[test]
+    fn oidc_startup_config_requires_secure_urls_matching_callback_path() {
+        let mut config = common::config::Config::default();
+        config.web_server.session_cookie_secure = true;
+        config.web_server.oidc = Some(OidcConfig {
+            issuer_url: "https://idp.example.com/realms/moonlight".to_string(),
+            client_id: "moonlight-web".to_string(),
+            client_secret: None,
+            redirect_url: "https://example.com/api/oidc/callback".to_string(),
+            scopes: vec!["openid".to_string()],
+            username_claim: "preferred_username".to_string(),
+            auto_create_missing_user: false,
+            display_label: "SSO".to_string(),
+        });
+
+        validate_oidc_startup_config(&config).expect("secure config should validate");
+
+        config
+            .web_server
+            .oidc
+            .as_mut()
+            .expect("oidc config should be set")
+            .redirect_url = "http://example.com/api/oidc/callback".to_string();
+        assert!(validate_oidc_startup_config(&config).is_err());
+
+        config
+            .web_server
+            .oidc
+            .as_mut()
+            .expect("oidc config should be set")
+            .redirect_url = "https://example.com/wrong/api/oidc/callback".to_string();
+        assert!(validate_oidc_startup_config(&config).is_err());
+
+        config
+            .web_server
+            .oidc
+            .as_mut()
+            .expect("oidc config should be set")
+            .redirect_url = "https://example.com/api/oidc/callback".to_string();
+        config.web_server.session_cookie_secure = false;
+        assert!(validate_oidc_startup_config(&config).is_err());
+
+        config.web_server.session_cookie_secure = true;
+        config
+            .web_server
+            .oidc
+            .as_mut()
+            .expect("oidc config should be set")
+            .issuer_url = "http://idp.example.com/realms/moonlight".to_string();
+        assert!(validate_oidc_startup_config(&config).is_err());
+
+        config
+            .web_server
+            .oidc
+            .as_mut()
+            .expect("oidc config should be set")
+            .issuer_url = "http://127.0.0.1:8080/realms/moonlight".to_string();
+        validate_oidc_startup_config(&config).expect("loopback HTTP issuer should be allowed");
+    }
+}

--- a/src/app/storage/json/mod.rs
+++ b/src/app/storage/json/mod.rs
@@ -30,12 +30,12 @@ use crate::app::{
     role::RoleId,
     storage::{
         Either, Storage, StorageHost, StorageHostAdd, StorageHostCache, StorageHostModify,
-        StorageHostPairInfo, StorageQueryHosts, StorageRole, StorageRoleAdd,
+        StorageHostPairInfo, StorageOidcIdentity, StorageQueryHosts, StorageRole, StorageRoleAdd,
         StorageRoleDefaultSettings, StorageRoleModify, StorageRolePermissions, StorageUser,
         StorageUserAdd, StorageUserModify,
         json::versions::{
-            Json, V2, V2Host, V2HostCache, V2HostPairInfo, V2UserPassword, V3, V3Role,
-            V3RolePermissions, V3RoleType, V3User, migrate_to_latest,
+            Json, V2, V2Host, V2HostCache, V2HostPairInfo, V2UserPassword, V3, V3OidcIdentity,
+            V3Role, V3RolePermissions, V3RoleType, V3User, migrate_to_latest,
         },
     },
     user::{RoleType, UserId},
@@ -296,6 +296,13 @@ fn user_from_json(user_id: UserId, user: &V3User) -> StorageUser {
         }),
         role_id: RoleId(user.role_id),
         client_unique_id: user.client_unique_id.clone(),
+        oidc_identity: user
+            .oidc_identity
+            .as_ref()
+            .map(|identity| StorageOidcIdentity {
+                issuer: identity.issuer.clone(),
+                subject: identity.subject.clone(),
+            }),
     }
 }
 
@@ -488,19 +495,32 @@ impl Storage for JsonStorage {
                 iterations: password.iterations,
             }),
             client_unique_id: user.client_unique_id,
+            oidc_identity: user.oidc_identity.map(|identity| V3OidcIdentity {
+                issuer: identity.issuer,
+                subject: identity.subject,
+            }),
         };
 
-        {
-            match self.get_user_by_name(&user.name).await {
-                Err(AppError::UserNotFound) => {
-                    // Fallthrough
-                }
-                Ok(_) => return Err(AppError::UserAlreadyExists),
-                Err(err) => return Err(err),
+        let mut users = self.users.write().await;
+
+        // Enforce username and OIDC identity uniqueness while holding the users
+        // write lock so concurrent provisioning cannot pass a check-then-insert race.
+        for existing in users.values() {
+            let existing = existing.read().await;
+            let duplicate_name = existing.name == user.name;
+            let duplicate_oidc_identity = user.oidc_identity.as_ref().is_some_and(|identity| {
+                existing
+                    .oidc_identity
+                    .as_ref()
+                    .is_some_and(|existing_identity| {
+                        existing_identity.issuer == identity.issuer
+                            && existing_identity.subject == identity.subject
+                    })
+            });
+            if duplicate_name || duplicate_oidc_identity {
+                return Err(AppError::UserAlreadyExists);
             }
         }
-
-        let mut users = self.users.write().await;
 
         let mut id;
         loop {
@@ -526,6 +546,10 @@ impl Storage for JsonStorage {
             }),
             role_id: RoleId(user.role_id),
             client_unique_id: user.client_unique_id,
+            oidc_identity: user.oidc_identity.map(|identity| StorageOidcIdentity {
+                issuer: identity.issuer,
+                subject: identity.subject,
+            }),
         })
     }
     async fn modify_user(
@@ -550,6 +574,12 @@ impl Storage for JsonStorage {
         }
         if let Some(client_unique_id) = modify.client_unique_id {
             user.client_unique_id = client_unique_id;
+        }
+        if let Some(oidc_identity) = modify.oidc_identity {
+            user.oidc_identity = oidc_identity.map(|identity| V3OidcIdentity {
+                issuer: identity.issuer,
+                subject: identity.subject,
+            });
         }
 
         drop(user);
@@ -578,6 +608,31 @@ impl Storage for JsonStorage {
 
             let user_id = UserId(*user_id);
             let user = (user.name == name).then(|| user_from_json(user_id, &user));
+
+            (user_id, user)
+        }))
+        .await;
+
+        let user = results.into_iter().find(|(_, user)| user.is_some());
+
+        user.ok_or(AppError::UserNotFound)
+    }
+    async fn get_user_by_oidc_identity(
+        &self,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<(UserId, Option<StorageUser>), AppError> {
+        let users = self.users.read().await;
+
+        let results = join_all(users.iter().map(|(user_id, user)| async move {
+            let user = user.read().await;
+
+            let user_id = UserId(*user_id);
+            let user = user
+                .oidc_identity
+                .as_ref()
+                .is_some_and(|identity| identity.issuer == issuer && identity.subject == subject)
+                .then(|| user_from_json(user_id, &user));
 
             (user_id, user)
         }))

--- a/src/app/storage/json/versions.rs
+++ b/src/app/storage/json/versions.rs
@@ -189,6 +189,7 @@ fn migrate_v2_to_v3(old: V2) -> V3 {
                             RoleType::Admin => ADMIN_ID,
                             RoleType::User => USER_ID,
                         },
+                        oidc_identity: None,
                     },
                 )
             })
@@ -216,6 +217,14 @@ pub struct V3User {
     pub name: String,
     pub password: Option<V2UserPassword>,
     pub client_unique_id: String,
+    #[serde(default)]
+    pub oidc_identity: Option<V3OidcIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct V3OidcIdentity {
+    pub issuer: String,
+    pub subject: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/storage/mod.rs
+++ b/src/app/storage/mod.rs
@@ -37,6 +37,12 @@ pub async fn create_storage(
 // - If two options are in a Modify struct it means: First option = change the field, second option = is this value null
 
 // --- User ---
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StorageOidcIdentity {
+    pub issuer: String,
+    pub subject: String,
+}
+
 #[derive(Clone)]
 pub struct StorageUser {
     pub id: UserId,
@@ -44,6 +50,8 @@ pub struct StorageUser {
     pub password: Option<StoragePassword>,
     pub role_id: RoleId,
     pub client_unique_id: String,
+    #[allow(dead_code)]
+    pub oidc_identity: Option<StorageOidcIdentity>,
 }
 #[derive(Clone)]
 pub struct StorageUserAdd {
@@ -51,12 +59,14 @@ pub struct StorageUserAdd {
     pub name: String,
     pub password: Option<StoragePassword>,
     pub client_unique_id: String,
+    pub oidc_identity: Option<StorageOidcIdentity>,
 }
 #[derive(Default, Clone)]
 pub struct StorageUserModify {
     pub role_id: Option<RoleId>,
     pub password: Option<Option<StoragePassword>>,
     pub client_unique_id: Option<String>,
+    pub oidc_identity: Option<Option<StorageOidcIdentity>>,
 }
 
 // --- Roles ---
@@ -189,6 +199,11 @@ pub trait Storage {
     /// The returned tuple can contain a StorageUser if the Storage thinks it's more efficient to query all data directly
     async fn get_user_by_name(&self, name: &str)
     -> Result<(UserId, Option<StorageUser>), AppError>;
+    async fn get_user_by_oidc_identity(
+        &self,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<(UserId, Option<StorageUser>), AppError>;
     async fn remove_user(&self, user_id: UserId) -> Result<(), AppError>;
     /// The returned tuple can contain a Vec<UserId> or Vec<StorageUser> if the Storage thinks it's more efficient to query all data directly
     async fn list_users(&self) -> Result<Either<Vec<UserId>, Vec<StorageUser>>, AppError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,15 @@ fn enable_ansi_windows() {
 struct ActixDebugSpan;
 
 impl ActixDebugSpan {
+    fn sanitized_uri(request: &ServiceRequest) -> String {
+        let uri = request.uri();
+        if request.path().contains("/api/oidc/") {
+            uri.path().to_string()
+        } else {
+            uri.to_string()
+        }
+    }
+
     fn sanitize_headers(headers: &HeaderMap) -> Vec<(String, String)> {
         const SENSITIVE: &[&str] = &["authorization", "cookie", "set-cookie"];
 
@@ -219,7 +228,7 @@ impl RootSpanBuilder for ActixDebugSpan {
                 Level::TRACE,
                 "http_request",
                 method = %request.method(),
-                uri = %request.uri(),
+                uri = %Self::sanitized_uri(request),
                 headers = ?Self::sanitize_headers(request.headers()),
                 peer_addr = ?request.peer_addr(),
             )
@@ -228,7 +237,7 @@ impl RootSpanBuilder for ActixDebugSpan {
                 Level::DEBUG,
                 "http_request",
                 method = %request.method(),
-                uri = %request.uri(),
+                uri = %Self::sanitized_uri(request),
             )
         }
     }

--- a/tests/json-stream-buffer.test.mjs
+++ b/tests/json-stream-buffer.test.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs"
+import assert from "node:assert/strict"
+
+const source = readFileSync(new URL("../web/api.ts", import.meta.url), "utf8")
+const classMatch = source.match(/class StreamedJsonResponse[\s\S]*?\n}\n\nexport async function fetchApi/)
+
+assert.ok(classMatch, "StreamedJsonResponse implementation was not found")
+const implementation = classMatch[0]
+
+assert.doesNotMatch(
+    implementation,
+    /\.split\("\\n",\s*2\)/,
+    "limited split drops buffered JSON records after the second newline",
+)
+assert.match(implementation, /indexOf\("\\n"\)/, "stream parser must locate one newline without discarding the remaining buffer")
+assert.match(implementation, /slice\(newlineIndex \+ 1\)/, "stream parser must preserve every byte after the consumed JSON line")

--- a/tests/oidc-login-order.test.mjs
+++ b/tests/oidc-login-order.test.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs"
+import assert from "node:assert/strict"
+
+const source = readFileSync(new URL("../web/component/modal/login.ts", import.meta.url), "utf8")
+const mountFormMatch = source.match(/mountForm\(form: HTMLFormElement\): void \{(?<body>[\s\S]*?)\n    \}/)
+
+assert.ok(mountFormMatch?.groups?.body, "ApiUserPasswordPrompt.mountForm was not found")
+
+const body = mountFormMatch.groups.body
+const usernameIndex = body.indexOf("this.name.mount(form)")
+const passwordIndex = body.indexOf("this.password.mount(form)")
+const passwordFileIndex = body.indexOf("this.passwordFile.mount(form)")
+const oidcIndex = body.indexOf("form.appendChild(this.oidcButton)")
+
+assert.notEqual(usernameIndex, -1, "username input is not mounted")
+assert.notEqual(passwordIndex, -1, "password input is not mounted")
+assert.notEqual(passwordFileIndex, -1, "password file input is not mounted")
+assert.notEqual(oidcIndex, -1, "OIDC button is not mounted")
+
+assert.ok(
+    usernameIndex < passwordIndex && passwordIndex < passwordFileIndex,
+    "local login controls must keep username, password, password file order",
+)
+assert.ok(
+    passwordFileIndex < oidcIndex,
+    "OIDC button must be mounted below all local login controls",
+)

--- a/web/api.ts
+++ b/web/api.ts
@@ -181,11 +181,10 @@ class StreamedJsonResponse<Initial, Other> {
 
             this.bufferedText += this.decoder.decode(value)
 
-            const split = this.bufferedText.split("\n", 2)
-            if (split.length == 2) {
-                this.bufferedText = split[1]
-
-                const text = split[0]
+            const newlineIndex = this.bufferedText.indexOf("\n")
+            if (newlineIndex >= 0) {
+                const text = this.bufferedText.slice(0, newlineIndex)
+                this.bufferedText = this.bufferedText.slice(newlineIndex + 1)
                 const json = JSON.parse(text)
 
                 return json

--- a/web/api.ts
+++ b/web/api.ts
@@ -1,4 +1,4 @@
-import { App, DeleteHostQuery, DeleteUserRequest, DetailedHost, DetailedUser, GetAppImageQuery, GetAppsQuery, GetAppsResponse, GetHostQuery, GetHostResponse, GetHostsResponse, GetUserQuery, GetUsersResponse, PatchUserRequest, PostCancelRequest, PostCancelResponse, PostLoginRequest, PostPairRequest, PostPairResponse1, PostPairResponse2, PostUserRequest, PostWakeUpRequest, PostHostRequest, PostHostResponse, UndetailedHost, PatchHostRequest, GetRolesResponse, UndetailedRole, GetRoleResponse, GetRoleQuery, DeleteRoleQuery, PatchRoleRequest, PostRoleResponse, PostRoleRequest, DetailedRole } from "./api_bindings.js";
+import { App, AuthMetadataResponse, DeleteHostQuery, DeleteUserRequest, DetailedHost, DetailedUser, GetAppImageQuery, GetAppsQuery, GetAppsResponse, GetHostQuery, GetHostResponse, GetHostsResponse, GetUserQuery, GetUsersResponse, PatchUserRequest, PostCancelRequest, PostCancelResponse, PostLoginRequest, PostPairRequest, PostPairResponse1, PostPairResponse2, PostUserRequest, PostWakeUpRequest, PostHostRequest, PostHostResponse, UndetailedHost, PatchHostRequest, GetRolesResponse, UndetailedRole, GetRoleResponse, GetRoleQuery, DeleteRoleQuery, PatchRoleRequest, PostRoleResponse, PostRoleRequest, DetailedRole } from "./api_bindings.js";
 import { showNotification } from "./component/notification.js";
 import { showMessage, showModal } from "./component/modal/index.js";
 import { ApiUserPasswordPrompt } from "./component/modal/login.js";
@@ -52,7 +52,11 @@ export async function tryLogin(): Promise<Api | null> {
 
     let api = { host_url, bearer: null, user: null, role: null }
 
-    const prompt = new ApiUserPasswordPrompt()
+    const metadata = await apiAuthMetadata(api)
+    const prompt = new ApiUserPasswordPrompt(metadata?.oidc ? {
+        displayLabel: metadata.oidc.display_label,
+        loginUrl: metadata.oidc.login_url,
+    } : undefined)
     const userAuth = await showModal(prompt)
 
     if (userAuth == null) {
@@ -256,6 +260,17 @@ export async function apiLogin(api: Api, request: PostLoginRequest): Promise<boo
     }
 
     return true
+}
+
+export async function apiAuthMetadata(api: Api): Promise<AuthMetadataResponse | null> {
+    try {
+        return await fetchApi(api, "/auth/metadata", GET) as AuthMetadataResponse
+    } catch (e) {
+        if (e instanceof FetchError) {
+            return null
+        }
+        throw e
+    }
 }
 
 export async function apiLogout(api: Api): Promise<boolean> {

--- a/web/component/modal/login.ts
+++ b/web/component/modal/login.ts
@@ -8,6 +8,11 @@ export type UserAuth = {
     password: string
 }
 
+export type OidcLogin = {
+    displayLabel: string,
+    loginUrl: string,
+}
+
 export class ApiUserPasswordPrompt extends FormModal<UserAuth> {
 
     private text: HTMLElement = document.createElement("h3")
@@ -15,12 +20,15 @@ export class ApiUserPasswordPrompt extends FormModal<UserAuth> {
     private name: InputComponent
     private password: InputComponent
     private passwordFile: InputComponent
+    private oidcLogin?: OidcLogin
+    private oidcButton: HTMLButtonElement = document.createElement("button")
 
-    constructor() {
+    constructor(oidcLogin?: OidcLogin) {
         super()
         const i = getTranslations(getCurrentLanguage()).modal
 
         this.text.innerText = i.login
+        this.oidcLogin = oidcLogin
 
         this.name = new InputComponent("ml-api-name", "text", i.username, {
             formRequired: true
@@ -32,6 +40,19 @@ export class ApiUserPasswordPrompt extends FormModal<UserAuth> {
 
         this.passwordFile = new InputComponent("ml-api-password-file", "file", i.passwordAsFile, { accept: ".txt" })
         this.passwordFile.addChangeListener(this.setFilePassword.bind(this))
+
+        this.oidcButton.type = "button"
+        this.oidcButton.innerText = oidcLogin ? `Sign in with ${oidcLogin.displayLabel}` : ""
+        this.oidcButton.addEventListener("click", () => {
+            if (!this.oidcLogin) {
+                return
+            }
+
+            const returnTo = `${window.location.pathname}${window.location.search}`
+            const loginUrl = new URL(this.oidcLogin.loginUrl, window.location.origin)
+            loginUrl.searchParams.set("return_to", returnTo)
+            window.location.assign(loginUrl.toString())
+        })
     }
 
     private async setFilePassword(event: ComponentEvent<InputComponent>) {
@@ -87,6 +108,10 @@ export class ApiUserPasswordPrompt extends FormModal<UserAuth> {
 
     mountForm(form: HTMLFormElement): void {
         form.appendChild(this.text)
+
+        if (this.oidcLogin) {
+            form.appendChild(this.oidcButton)
+        }
 
         this.name.mount(form)
 

--- a/web/component/modal/login.ts
+++ b/web/component/modal/login.ts
@@ -109,13 +109,13 @@ export class ApiUserPasswordPrompt extends FormModal<UserAuth> {
     mountForm(form: HTMLFormElement): void {
         form.appendChild(this.text)
 
-        if (this.oidcLogin) {
-            form.appendChild(this.oidcButton)
-        }
-
         this.name.mount(form)
 
         this.password.mount(form)
         this.passwordFile.mount(form)
+
+        if (this.oidcLogin) {
+            form.appendChild(this.oidcButton)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds native, standards-based OpenID Connect authentication while retaining local username/password access as a break-glass path.

- Uses issuer discovery rather than Keycloak-specific endpoint paths
- Implements authorization-code flow with PKCE S256
- Validates state, nonce, signature, issuer, audience, expiry and `at_hash`
- Binds identities to immutable issuer + subject values
- Keeps provider tokens server-side
- Makes automatic provisioning opt-in and least-privilege by default
- Adds configurable provider label, scopes and username claim
- Places the provider-specific sign-in action after the local controls
- Fixes streamed JSON buffering when multiple host records arrive in one chunk

## Security properties

- Secure, HttpOnly, SameSite pending-login and session cookies
- Bounded pending-login state with expiry and single-use consumption
- Exact redirect handling and no untrusted post-login redirects
- No username-only automatic account linking
- Local password authentication remains available independently

## Verification

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run build`
- [x] Regression tests for login-control order and streamed JSON buffering
- [x] Live browser authorization-code flow, host listing, application listing and logout
- [x] Tested with Keycloak using PKCE S256

## Compatibility

The implementation uses standard OIDC discovery and is not tied to Keycloak endpoint paths. Keycloak is the live-tested provider; tests also cover provider discovery and token-validation behavior.

## Maintained repository

A standalone maintained repository is available at https://github.com/sweets9/moonlight-web-stream-oidc for issue tracking and follow-on contributions.

