### PR TITLE
Pairing UX: real failure reasons, countdown, cancel, and duplicate-attempt guard

### DIFF
--- a/common/src/api_bindings.rs
+++ b/common/src/api_bindings.rs
@@ -169,19 +169,56 @@ pub struct PostPairRequest {
     pub host_id: u32,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, TS)]
+#[ts(export, export_to = EXPORT_PATH)]
+pub enum PairFailReason {
+    /// The PIN entered on the host did not match.
+    PinIncorrect,
+    /// The pairing window expired before a PIN was entered on the host.
+    TimedOut,
+    /// The host is already paired.
+    AlreadyPaired,
+    /// A pairing attempt for this host is already running (either from this
+    /// server or from another client on the host side).
+    PairingInProgress,
+    /// The pairing attempt was cancelled via `POST /pair/cancel`.
+    Cancelled,
+    /// The host could not be reached over the network.
+    HostUnreachable,
+    /// Any other error. See `detail`.
+    Internal,
+}
+
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export, export_to = EXPORT_PATH)]
 pub enum PostPairResponse1 {
     InternalServerError,
     PairError,
-    Pin(String),
+    PairFailed {
+        reason: PairFailReason,
+        detail: Option<String>,
+    },
+    Pin {
+        pin: String,
+        expires_in_secs: u64,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export, export_to = EXPORT_PATH)]
 pub enum PostPairResponse2 {
     PairError,
+    PairFailed {
+        reason: PairFailReason,
+        detail: Option<String>,
+    },
     Paired(DetailedHost),
+}
+
+#[derive(Serialize, Deserialize, Debug, TS)]
+#[ts(export, export_to = EXPORT_PATH)]
+pub struct PostPairCancelRequest {
+    pub host_id: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]

--- a/docs/superpowers/specs/2026-07-30-pairing-ux-design.md
+++ b/docs/superpowers/specs/2026-07-30-pairing-ux-design.md
@@ -1,0 +1,61 @@
+# Pairing UX overhaul — design
+
+Date: 2026-07-30. Approved by Joey before implementation.
+
+## Problem
+
+Pairing failures surface as a bare `"PairError"` string. Users cannot tell a wrong
+PIN from a timeout from a concurrent-attempt collision (issues #143, #26, #19 are
+all this wall). Additional hazards discovered while diagnosing a live setup:
+
+- The pairing window is 5 minutes, but the UI never says so; a PIN entered after
+  expiry fails with no explanation.
+- A second pair attempt while one is pending corrupts Sunshine's pending pair
+  session (Sunshine keys sessions by client uniqueid and `emplace` never
+  refreshes an existing entry; a stale/raced PIN leaves the session mid-phase and
+  every later attempt fails with "Out of order call to getservercert" until
+  Sunshine restarts).
+- `src/app/host.rs` hardcodes the device name `"roth"` instead of using the
+  `moonlight.pair_device_name` config value (separate small PR).
+
+## Changes
+
+### Protocol (`common/src/api_bindings.rs`, ts-rs exported)
+
+- `PostPairResponse1::Pin(String)` → `Pin { pin: String, expires_in_secs: u64 }`.
+- `PostPairResponse2` gains `PairFailed { reason: PairFailReason, detail: Option<String> }`.
+- New `PairFailReason` enum: `PinIncorrect | TimedOut | AlreadyPaired |
+  PairingInProgress | HostUnreachable | Internal`.
+- Legacy `PairError` variants stay for old clients; the shipped web client
+  upgrades with the server, third-party consumers keep working.
+
+### Server (`src/api/host.rs`, `src/app/host.rs`)
+
+- Map the `AppError`/`MoonlightClientError` chain to `PairFailReason` + detail
+  string instead of discarding it in a `warn!`.
+- Per-host in-flight guard: a concurrent `POST /pair` for the same host returns
+  `PairFailed { reason: PairingInProgress }` immediately. Rejecting (rather than
+  cancel-and-replace) is deliberate: racing attempts poison Sunshine's pending
+  session (see above).
+- `POST /pair/cancel { host_id }`: aborts the in-flight attempt (drops the pair
+  future, sends `/unpair` best-effort, clears the guard) so a lost modal doesn't
+  lock the host for 5 minutes.
+
+### Client (`web/component/host/`, `web/locales/*.ts`)
+
+- Pair modal: PIN + live countdown driven by `expires_in_secs`; Cancel button
+  wired to `/pair/cancel`.
+- Human, localized message per `PairFailReason` in all 5 locales (en, fr-FR,
+  ko-KR, pt-BR, zh-CN). `PinIncorrect` message includes the stale-session hint:
+  restart Sunshine if retries keep failing.
+
+## Testing
+
+- Rust unit tests for error → reason mapping and the in-flight guard.
+- Live e2e against Sunshine 2025.924: happy path, wrong PIN, expiry, duplicate
+  attempt, cancel-then-retry.
+
+## Out of scope
+
+Sunshine's stale-session bug itself (filed upstream at LizardByte separately);
+latency work (#136); zombie streams (#98); sidebar/env fixes (#155/#148).

--- a/src/api/host.rs
+++ b/src/api/host.rs
@@ -4,19 +4,21 @@ use actix_web::{
     web::{Data, Json, Query},
 };
 use common::api_bindings::{
-    DeleteHostQuery, GetHostQuery, GetHostResponse, GetHostsResponse, PatchHostRequest,
-    PostHostRequest, PostHostResponse, PostPairRequest, PostPairResponse1, PostPairResponse2,
-    PostWakeUpRequest, UndetailedHost,
+    DeleteHostQuery, GetHostQuery, GetHostResponse, GetHostsResponse, PairFailReason,
+    PatchHostRequest, PostHostRequest, PostHostResponse, PostPairCancelRequest, PostPairRequest,
+    PostPairResponse1, PostPairResponse2, PostWakeUpRequest, UndetailedHost,
 };
 use futures::future::try_join_all;
-use moonlight_common::{crypto::openssl::OpenSSLCryptoBackend, http::pair::PairPin};
+use moonlight_common::{
+    crypto::openssl::OpenSSLCryptoBackend, high::MoonlightClientError, http::pair::PairPin,
+};
 use tracing::warn;
 
 use crate::{
     api::response_streaming::StreamedResponse,
     app::{
         App, AppError,
-        host::HostId,
+        host::{Host, HostId},
         storage::StorageHostModify,
         user::{AuthenticatedUser, RoleType, UserId},
     },
@@ -145,6 +147,35 @@ async fn delete_host(
     Ok(HttpResponse::Ok().finish())
 }
 
+/// Maps a pairing failure onto the reason communicated to the client, plus a
+/// human-readable detail string.
+fn pair_fail_reason(err: &AppError) -> (PairFailReason, Option<String>) {
+    use moonlight_common::http::pair::client::ClientPairingError;
+
+    let reason = match err {
+        AppError::PairingInProgress => PairFailReason::PairingInProgress,
+        AppError::PairingTimedOut => PairFailReason::TimedOut,
+        AppError::PairingCancelled => PairFailReason::Cancelled,
+        AppError::HostPaired => PairFailReason::AlreadyPaired,
+        AppError::HostNotFound => PairFailReason::HostUnreachable,
+        AppError::Moonlight(err) => match err {
+            MoonlightClientError::Pairing(ClientPairingError::FailedWrongPin) => {
+                PairFailReason::PinIncorrect
+            }
+            MoonlightClientError::Pairing(ClientPairingError::FailedAlreadyInProgress) => {
+                PairFailReason::PairingInProgress
+            }
+            MoonlightClientError::Offline | MoonlightClientError::Backend(_) => {
+                PairFailReason::HostUnreachable
+            }
+            _ => PairFailReason::Internal,
+        },
+        _ => PairFailReason::Internal,
+    };
+
+    (reason, Some(err.to_string()))
+}
+
 #[post("/pair")]
 async fn pair_host(
     mut user: AuthenticatedUser,
@@ -156,8 +187,10 @@ async fn pair_host(
 
     let pin = PairPin::new_random(&OpenSSLCryptoBackend)?;
 
-    let (stream_response, stream_sender) =
-        StreamedResponse::new(PostPairResponse1::Pin(pin.to_string()));
+    let (stream_response, stream_sender) = StreamedResponse::new(PostPairResponse1::Pin {
+        pin: pin.to_string(),
+        expires_in_secs: Host::PAIR_TIMEOUT_SECS,
+    });
 
     spawn(async move {
         let result = host.pair(&mut user, pin).await;
@@ -178,7 +211,11 @@ async fn pair_host(
             }
             Err(err) => {
                 warn!("Failed to pair host: {err}");
-                if let Err(err) = stream_sender.send(PostPairResponse2::PairError).await {
+                let (reason, detail) = pair_fail_reason(&err);
+                if let Err(err) = stream_sender
+                    .send(PostPairResponse2::PairFailed { reason, detail })
+                    .await
+                {
                     warn!("Failed to send pair failure: {err}");
                 }
             }
@@ -186,6 +223,20 @@ async fn pair_host(
     });
 
     Ok(stream_response)
+}
+
+#[post("/pair/cancel")]
+async fn pair_cancel_host(
+    mut user: AuthenticatedUser,
+    Json(request): Json<PostPairCancelRequest>,
+) -> Result<HttpResponse, AppError> {
+    let host_id = HostId(request.host_id);
+
+    let host = user.host(host_id).await?;
+
+    host.pair_cancel()?;
+
+    Ok(HttpResponse::Ok().finish())
 }
 
 #[post("/host/wake")]

--- a/src/api/host.rs
+++ b/src/api/host.rs
@@ -185,6 +185,17 @@ async fn pair_host(
 
     let mut host = user.host(host_id).await?;
 
+    // Advisory pre-check so a duplicate attempt is rejected before the client
+    // ever sees a pin; `Host::pair` still guards atomically against races.
+    if host.pair_in_progress()? {
+        let (reason, detail) = pair_fail_reason(&AppError::PairingInProgress);
+        return Ok(StreamedResponse::new(PostPairResponse1::PairFailed {
+            reason,
+            detail,
+        })
+        .0);
+    }
+
     let pin = PairPin::new_random(&OpenSSLCryptoBackend)?;
 
     let (stream_response, stream_sender) = StreamedResponse::new(PostPairResponse1::Pin {
@@ -251,4 +262,58 @@ async fn wake_host(
     host.wake(&mut user).await?;
 
     Ok(HttpResponse::Ok().finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moonlight_common::http::pair::client::ClientPairingError;
+
+    fn reason_of(err: AppError) -> PairFailReason {
+        pair_fail_reason(&err).0
+    }
+
+    #[test]
+    fn pairing_lifecycle_errors_map_to_their_reason() {
+        assert_eq!(
+            reason_of(AppError::PairingInProgress),
+            PairFailReason::PairingInProgress
+        );
+        assert_eq!(
+            reason_of(AppError::PairingTimedOut),
+            PairFailReason::TimedOut
+        );
+        assert_eq!(
+            reason_of(AppError::PairingCancelled),
+            PairFailReason::Cancelled
+        );
+        assert_eq!(reason_of(AppError::HostPaired), PairFailReason::AlreadyPaired);
+    }
+
+    #[test]
+    fn moonlight_pairing_errors_map_to_their_reason() {
+        assert_eq!(
+            reason_of(AppError::Moonlight(MoonlightClientError::Pairing(
+                ClientPairingError::FailedWrongPin
+            ))),
+            PairFailReason::PinIncorrect
+        );
+        assert_eq!(
+            reason_of(AppError::Moonlight(MoonlightClientError::Pairing(
+                ClientPairingError::FailedAlreadyInProgress
+            ))),
+            PairFailReason::PairingInProgress
+        );
+        assert_eq!(
+            reason_of(AppError::Moonlight(MoonlightClientError::Offline)),
+            PairFailReason::HostUnreachable
+        );
+    }
+
+    #[test]
+    fn unknown_errors_fall_back_to_internal_with_detail() {
+        let (reason, detail) = pair_fail_reason(&AppError::Forbidden);
+        assert_eq!(reason, PairFailReason::Internal);
+        assert!(detail.is_some());
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,7 +8,10 @@ use actix_web::{
 use crate::api::{
     app::{get_app_image, get_apps},
     auth::auth_middleware,
-    host::{delete_host, get_host, list_hosts, pair_host, patch_host, post_host, wake_host},
+    host::{
+        delete_host, get_host, list_hosts, pair_cancel_host, pair_host, patch_host, post_host,
+        wake_host,
+    },
     role::{add_role, delete_role, get_role, list_roles, patch_role},
     settings::{get_default_settings, get_permissions},
     user::{add_user, delete_user, get_user, list_users, patch_user},
@@ -42,6 +45,7 @@ pub fn api_service() -> impl HttpServiceFactory {
             wake_host,
             delete_host,
             pair_host,
+            pair_cancel_host,
         ])
         .service(services![
             // -- Apps

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -363,6 +363,20 @@ impl Host {
     /// before giving up. Also reported to clients as `expires_in_secs`.
     pub const PAIR_TIMEOUT_SECS: u64 = 300;
 
+    /// Whether a pairing attempt for this host is currently in flight.
+    ///
+    /// Only advisory (the attempt can finish right after this returns);
+    /// `pair` itself registers atomically and is the actual guard.
+    pub fn pair_in_progress(&self) -> Result<bool, AppError> {
+        let app = self.app.access()?;
+
+        let sessions = app
+            .pairing_sessions
+            .lock()
+            .expect("pairing_sessions lock poisoned");
+        Ok(sessions.contains_key(&self.id))
+    }
+
     /// Cancels the in-flight pairing attempt for this host, if any.
     pub fn pair_cancel(&self) -> Result<(), AppError> {
         let app = self.app.access()?;

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -359,6 +359,27 @@ impl Host {
         }
     }
 
+    /// How long a pairing attempt waits for the pin to be entered on the host
+    /// before giving up. Also reported to clients as `expires_in_secs`.
+    pub const PAIR_TIMEOUT_SECS: u64 = 300;
+
+    /// Cancels the in-flight pairing attempt for this host, if any.
+    pub fn pair_cancel(&self) -> Result<(), AppError> {
+        let app = self.app.access()?;
+
+        let sender = app
+            .pairing_sessions
+            .lock()
+            .expect("pairing_sessions lock poisoned")
+            .remove(&self.id)
+            .ok_or(AppError::PairingNotInProgress)?;
+
+        // The receiver half lives inside `pair`; if it is already gone the
+        // attempt just finished on its own, which is fine.
+        let _ = sender.send(());
+        Ok(())
+    }
+
     pub async fn pair(
         &mut self,
         user: &mut AuthenticatedUser,
@@ -378,8 +399,77 @@ impl Host {
             return Err(AppError::HostPaired);
         }
 
+        // Register this attempt, rejecting a concurrent one for the same
+        // host. See `AppInner::pairing_sessions` for why racing attempts are
+        // dangerous rather than merely wasteful.
+        let mut cancel_receiver = {
+            let mut sessions = app
+                .pairing_sessions
+                .lock()
+                .expect("pairing_sessions lock poisoned");
+            if sessions.contains_key(&self.id) {
+                return Err(AppError::PairingInProgress);
+            }
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            sessions.insert(self.id, sender);
+            receiver
+        };
+
+        let result = tokio::select! {
+            result = tokio::time::timeout(
+                std::time::Duration::from_secs(Self::PAIR_TIMEOUT_SECS),
+                self.pair_inner(user_id, user.clone(), &app, pin),
+            ) => match result {
+                Ok(result) => result,
+                Err(_elapsed) => Err(AppError::PairingTimedOut),
+            },
+            _ = &mut cancel_receiver => Err(AppError::PairingCancelled),
+        };
+
+        app.pairing_sessions
+            .lock()
+            .expect("pairing_sessions lock poisoned")
+            .remove(&self.id);
+
+        match result {
+            Ok(modify) => self.modify(user, modify).await,
+            Err(err) => {
+                // On timeout/cancel the pair future was dropped mid-flight, so
+                // the library's own unpair-on-error cleanup did not run. Tell
+                // the host to drop its pending pair session so a fresh attempt
+                // can start cleanly.
+                if matches!(
+                    err,
+                    AppError::PairingTimedOut | AppError::PairingCancelled
+                ) {
+                    let mut user = user.clone();
+                    match self
+                        .use_client(&app, &mut user, async |_, host| host.unpair().await)
+                        .await
+                    {
+                        Ok(Ok(())) | Err(_) => {}
+                        Ok(Err(unpair_err)) => {
+                            tracing::debug!(
+                                "best-effort unpair after aborted pairing failed: {unpair_err}"
+                            );
+                        }
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn pair_inner(
+        &mut self,
+        user_id: UserId,
+        mut user: AuthenticatedUser,
+        app: &AppInner,
+        pin: PairPin,
+    ) -> Result<StorageHostModify, AppError> {
+        let user = &mut user;
         let modify = self
-            .use_client(&app, user, async |this, host| {
+            .use_client(app, user, async |this, host| {
                 let (client_identifier, client_secret) = OpenSSLCryptoBackend
                     .generate_client_identity()
                     .map_err(|err| {
@@ -419,7 +509,7 @@ impl Host {
             })
             .await??;
 
-        self.modify(user, modify).await
+        Ok(modify)
     }
 
     pub async fn wake(&self, user: &mut AuthenticatedUser) -> Result<(), AppError> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io, mem,
     ops::Deref,
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex as StdMutex, Weak},
 };
 
 use actix_web::{ResponseError, http::StatusCode, web::Bytes};
@@ -54,6 +54,14 @@ pub enum AppError {
     HostPaired,
     #[error("the host must be paired for this action")]
     HostNotPaired,
+    #[error("a pairing attempt for this host is already in progress")]
+    PairingInProgress,
+    #[error("the pairing attempt timed out before the pin was entered on the host")]
+    PairingTimedOut,
+    #[error("the pairing attempt was cancelled")]
+    PairingCancelled,
+    #[error("there is no pairing attempt in progress for this host")]
+    PairingNotInProgress,
     // -- Unauthorized
     #[error("the credentials don't exists")]
     CredentialsWrong,
@@ -99,6 +107,10 @@ impl ResponseError for AppError {
             Self::HostNotFound => StatusCode::NOT_FOUND,
             Self::HostNotPaired => StatusCode::FORBIDDEN,
             Self::HostPaired => StatusCode::NOT_MODIFIED,
+            Self::PairingInProgress => StatusCode::CONFLICT,
+            Self::PairingTimedOut => StatusCode::REQUEST_TIMEOUT,
+            Self::PairingCancelled => StatusCode::OK,
+            Self::PairingNotInProgress => StatusCode::NOT_FOUND,
             Self::UserNotFound => StatusCode::NOT_FOUND,
             Self::RoleNotFound => StatusCode::NOT_FOUND,
             Self::UserAlreadyExists => StatusCode::CONFLICT,
@@ -136,6 +148,12 @@ struct AppInner {
     config: Config,
     storage: Arc<dyn Storage + Send + Sync>,
     app_image_cache: RwLock<HashMap<(UserId, HostId, AppId), Bytes>>,
+    /// Hosts with a pairing attempt in flight, with a sender to cancel it.
+    /// Guards against concurrent attempts for the same host: racing attempts
+    /// corrupt Sunshine's pending pair session (it keys sessions by client
+    /// uniqueid and never refreshes an existing entry), which makes every
+    /// later attempt fail until Sunshine restarts.
+    pairing_sessions: StdMutex<HashMap<HostId, tokio::sync::oneshot::Sender<()>>>,
 }
 
 pub type MoonlightClient = TokioHyperClient;
@@ -150,6 +168,7 @@ impl App {
             storage: create_storage(config.data_storage.clone()).await?,
             config,
             app_image_cache: Default::default(),
+            pairing_sessions: Default::default(),
         };
 
         Ok(Self {

--- a/web/api.ts
+++ b/web/api.ts
@@ -1,4 +1,4 @@
-import { App, DeleteHostQuery, DeleteUserRequest, DetailedHost, DetailedUser, GetAppImageQuery, GetAppsQuery, GetAppsResponse, GetHostQuery, GetHostResponse, GetHostsResponse, GetUserQuery, GetUsersResponse, PatchUserRequest, PostCancelRequest, PostCancelResponse, PostLoginRequest, PostPairRequest, PostPairResponse1, PostPairResponse2, PostUserRequest, PostWakeUpRequest, PostHostRequest, PostHostResponse, UndetailedHost, PatchHostRequest, GetRolesResponse, UndetailedRole, GetRoleResponse, GetRoleQuery, DeleteRoleQuery, PatchRoleRequest, PostRoleResponse, PostRoleRequest, DetailedRole } from "./api_bindings.js";
+import { App, DeleteHostQuery, DeleteUserRequest, DetailedHost, DetailedUser, GetAppImageQuery, GetAppsQuery, GetAppsResponse, GetHostQuery, GetHostResponse, GetHostsResponse, GetUserQuery, GetUsersResponse, PatchUserRequest, PostCancelRequest, PostCancelResponse, PostLoginRequest, PostPairCancelRequest, PostPairRequest, PostPairResponse1, PostPairResponse2, PostUserRequest, PostWakeUpRequest, PostHostRequest, PostHostResponse, UndetailedHost, PatchHostRequest, GetRolesResponse, UndetailedRole, GetRoleResponse, GetRoleQuery, DeleteRoleQuery, PatchRoleRequest, PostRoleResponse, PostRoleRequest, DetailedRole } from "./api_bindings.js";
 import { showNotification } from "./component/notification.js";
 import { showMessage, showModal } from "./component/modal/index.js";
 import { ApiUserPasswordPrompt } from "./component/modal/login.js";
@@ -392,6 +392,13 @@ export async function apiPostPair(api: Api, request: PostPairRequest): Promise<S
         json: request,
         response: "jsonStreaming",
         noTimeout: true
+    })
+}
+
+export async function apiPostPairCancel(api: Api, request: PostPairCancelRequest): Promise<void> {
+    await fetchApi(api, "/pair/cancel", "post", {
+        json: request,
+        response: "ignore"
     })
 }
 

--- a/web/component/host/index.ts
+++ b/web/component/host/index.ts
@@ -1,10 +1,11 @@
-import { DetailedHost, DetailedUser, UndetailedHost } from "../../api_bindings.js"
-import { Api, apiDeleteHost, apiGetHost, isDetailedHost, apiPostPair, apiWakeUp, apiGetUser, apiPatchHost } from "../../api.js"
+import { DetailedHost, DetailedUser, PairFailReason, UndetailedHost } from "../../api_bindings.js"
+import { Api, apiDeleteHost, apiGetHost, isDetailedHost, apiPostPair, apiPostPairCancel, apiWakeUp, apiGetUser, apiPatchHost } from "../../api.js"
 import { Component, ComponentEvent } from "../index.js"
 import { getCurrentLanguage, getTranslations } from "../../i18n.js"
 import { setContextMenu } from "../context_menu.js"
 import { showNotification } from "../notification.js"
-import { showMessage } from "../modal/index.js"
+import { showMessage, showModal } from "../modal/index.js"
+import { PairModal } from "./pair_modal.js"
 import { HOST_IMAGE, HOST_OVERLAY_LOCK, HOST_OVERLAY_NONE, HOST_OVERLAY_OFFLINE } from "../../resources/index.js"
 
 export type HostEventListener = (event: ComponentEvent<Host>) => void
@@ -234,12 +235,31 @@ export class Host implements Component {
             host_id: this.getHostId()
         })
 
-        if (typeof responseStream.response == "string") {
-            throw `failed to pair (stage 1): ${responseStream.response}`
+        const stage1 = responseStream.response
+        if (typeof stage1 == "string") {
+            // Legacy servers: "InternalServerError" | "PairError"
+            throw `failed to pair (stage 1): ${stage1}`
+        }
+        if ("PairFailed" in stage1) {
+            showMessage(this.pairFailMessage(stage1.PairFailed.reason, stage1.PairFailed.detail))
+            return
         }
 
+        const { pin, expires_in_secs } = stage1.Pin
+
         const messageAbort = new AbortController()
-        showMessage(i.pairPrompt(this.getCache()?.name ?? "", responseStream.response.Pin), { signal: messageAbort.signal })
+        const pairModal = new PairModal(
+            this.getCache()?.name ?? "",
+            pin,
+            Number(expires_in_secs),
+            { signal: messageAbort.signal },
+        )
+        showModal(pairModal).then(output => {
+            if (output == "cancelled") {
+                apiPostPairCancel(this.api, { host_id: this.getHostId() })
+                    .catch(err => showNotification(`${err}`))
+            }
+        })
 
         const resultResponse = await responseStream.next()
         messageAbort.abort()
@@ -247,10 +267,31 @@ export class Host implements Component {
         if (!resultResponse) {
             throw "missing stage 2 of pairing"
         } else if (typeof resultResponse == "string") {
+            // Legacy servers: "PairError"
             throw `failed to pair (stage 2): ${resultResponse}`
         }
 
+        if ("PairFailed" in resultResponse) {
+            const { reason, detail } = resultResponse.PairFailed
+            if (reason != "Cancelled") {
+                showMessage(this.pairFailMessage(reason, detail))
+            }
+            return
+        }
+
         this.updateCache(resultResponse.Paired, null)
+    }
+
+    private pairFailMessage(reason: PairFailReason, detail: string | null): string {
+        const i = getTranslations(getCurrentLanguage()).host
+        const message = i.pairFailReason[reason] ?? i.pairFailReason.Internal
+
+        // Reasons with a dedicated message are self-explanatory; for the
+        // catch-all, surface the technical detail to make bug reports useful.
+        if (reason == "Internal" && detail) {
+            return `${message}\n(${detail})`
+        }
+        return message
     }
 
     getHostId(): number {

--- a/web/component/host/pair_modal.ts
+++ b/web/component/host/pair_modal.ts
@@ -1,0 +1,83 @@
+import { Component } from "../index.js"
+import { Modal } from "../modal/index.js"
+import { getCurrentLanguage, getTranslations } from "../../i18n.js"
+
+type PairModalInit = {
+    signal?: AbortSignal
+}
+
+export type PairModalOutput = "cancelled"
+
+/// Modal shown while a pairing attempt is in flight: displays the pin, a
+/// countdown for the pairing window, and a cancel button. Resolves with
+/// "cancelled" when the user cancels, or null when closed via the signal
+/// (pairing finished on its own).
+export class PairModal implements Component, Modal<PairModalOutput | null> {
+
+    private signal?: AbortSignal
+    private textElement: HTMLElement = document.createElement("p")
+    private countdownElement: HTMLElement = document.createElement("p")
+    private cancelButton: HTMLButtonElement = document.createElement("button")
+
+    private secondsLeft: number
+    private countdownInterval: ReturnType<typeof setInterval> | null = null
+
+    constructor(hostName: string, pin: string, expiresInSecs: number, init?: PairModalInit) {
+        const i = getTranslations(getCurrentLanguage()).host
+        this.textElement.innerText = i.pairPrompt(hostName, pin)
+
+        this.secondsLeft = expiresInSecs
+        this.countdownElement.innerText = i.pairCountdown(this.secondsLeft)
+
+        this.cancelButton.innerText = i.pairCancel
+
+        this.signal = init?.signal
+    }
+
+    mount(parent: HTMLElement): void {
+        parent.appendChild(this.textElement)
+        parent.appendChild(this.countdownElement)
+        parent.appendChild(this.cancelButton)
+    }
+    unmount(parent: HTMLElement): void {
+        parent.removeChild(this.textElement)
+        parent.removeChild(this.countdownElement)
+        parent.removeChild(this.cancelButton)
+    }
+
+    onFinish(abort: AbortSignal): Promise<PairModalOutput | null> {
+        this.countdownInterval = setInterval(() => {
+            const i = getTranslations(getCurrentLanguage()).host
+            this.secondsLeft = Math.max(0, this.secondsLeft - 1)
+            this.countdownElement.innerText = i.pairCountdown(this.secondsLeft)
+        }, 1000)
+
+        return new Promise(resolve => {
+            let customController: AbortController | null = null
+
+            const finish = (output: PairModalOutput | null) => {
+                if (this.countdownInterval != null) {
+                    clearInterval(this.countdownInterval)
+                    this.countdownInterval = null
+                }
+                resolve(output)
+                customController?.abort()
+            }
+
+            if (this.signal) {
+                customController = new AbortController()
+                this.signal.addEventListener("abort", () => {
+                    finish(null)
+                }, { once: true, signal: customController.signal })
+            }
+
+            this.cancelButton.addEventListener("click", () => {
+                finish("cancelled")
+            }, { signal: customController?.signal })
+
+            if (customController) {
+                abort.addEventListener("abort", customController.abort.bind(customController))
+            }
+        })
+    }
+}

--- a/web/locales/en.ts
+++ b/web/locales/en.ts
@@ -1,3 +1,4 @@
+import type { PairFailReason } from "../api_bindings.js"
 export const en = {
     index: {
         appTitle: "Moonlight Web",
@@ -143,6 +144,17 @@ export const en = {
         wakeUpSent: "Sent Wake Up packet. It might take a moment for your pc to start.",
         alreadyPaired: "This host is already paired!",
         pairPrompt: (name: string, pin: string) => `Please pair your host ${name} with this pin:\nPin: ${pin}`,
+        pairCountdown: (secs: number) => `Enter the PIN on the host within ${Math.floor(secs / 60)}:${("0" + (secs % 60)).slice(-2)}`,
+        pairCancel: "Cancel Pairing",
+        pairFailReason: {
+            PinIncorrect: "The PIN didn't match. If it keeps failing after retries, restart Sunshine on the host \u2014 a stale pairing attempt can block new ones.",
+            TimedOut: "Pairing timed out before the PIN was entered on the host.",
+            AlreadyPaired: "This host is already paired!",
+            PairingInProgress: "Another pairing attempt for this host is already running. Wait for it to finish or cancel it first.",
+            Cancelled: "Pairing was cancelled.",
+            HostUnreachable: "Couldn't reach the host. Is Sunshine running?",
+            Internal: "Pairing failed unexpectedly.",
+        } satisfies Record<PairFailReason, string>,
         overwriteMismatch: (currentId: number, incomingId: number) => `tried to overwrite host ${currentId} with data from ${incomingId}`,
         details: (host: any) =>
             `Web Id: ${host.host_id}\n` +

--- a/web/locales/fr-FR.ts
+++ b/web/locales/fr-FR.ts
@@ -145,6 +145,17 @@ export const frFr: Translations = {
         wakeUpSent: "Signal de réveil envoyé. Le PC peut prendre un peu de temps pour démarrer.",
         alreadyPaired: "Hôte déjà appairé !",
         pairPrompt: (name: string, pin: string) => `Veuillez appairer votre hôte ${name} avec ce NIP :\nNIP: ${pin}`,
+        pairCountdown: (secs: number) => `Saisissez le code PIN sur l'h\u00f4te avant ${Math.floor(secs / 60)}:${("0" + (secs % 60)).slice(-2)}`,
+        pairCancel: "Annuler l'appairage",
+        pairFailReason: {
+            PinIncorrect: "Le code PIN ne correspond pas. Si l'\u00e9chec persiste apr\u00e8s plusieurs essais, red\u00e9marrez Sunshine sur l'h\u00f4te \u2014 une tentative d'appairage obsol\u00e8te peut bloquer les nouvelles.",
+            TimedOut: "L'appairage a expir\u00e9 avant la saisie du code PIN sur l'h\u00f4te.",
+            AlreadyPaired: "Cet h\u00f4te est d\u00e9j\u00e0 appair\u00e9 !",
+            PairingInProgress: "Une autre tentative d'appairage est d\u00e9j\u00e0 en cours pour cet h\u00f4te. Attendez qu'elle se termine ou annulez-la d'abord.",
+            Cancelled: "Appairage annul\u00e9.",
+            HostUnreachable: "Impossible de joindre l'h\u00f4te. Sunshine est-il lanc\u00e9 ?",
+            Internal: "L'appairage a \u00e9chou\u00e9 de mani\u00e8re inattendue.",
+        },
         overwriteMismatch: (currentId: number, incomingId: number) => `tentative d'écrasement de l'hôte ${currentId} avec les données de ${incomingId}`,
         details: (host: any) =>
             `Identifiant Web : ${host.host_id}\n` +

--- a/web/locales/ko-KR.ts
+++ b/web/locales/ko-KR.ts
@@ -145,6 +145,17 @@ export const koKR: Translations = {
         wakeUpSent: "매직 패킷을 전송했습니다. PC가 켜질 때까지 잠시 기다려 주세요.",
         alreadyPaired: "이 호스트는 이미 페어링되어 있습니다!",
         pairPrompt: (name: string, pin: string) => `호스트 ${name}에서 아래 PIN 번호를 입력해 주세요:\nPIN: ${pin}`,
+        pairCountdown: (secs: number) => `${Math.floor(secs / 60)}:${("0" + (secs % 60)).slice(-2)} \uc548\uc5d0 \ud638\uc2a4\ud2b8\uc5d0\uc11c PIN\uc744 \uc785\ub825\ud558\uc138\uc694`,
+        pairCancel: "\ud398\uc5b4\ub9c1 \ucde8\uc18c",
+        pairFailReason: {
+            PinIncorrect: "PIN\uc774 \uc77c\uce58\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \uc7ac\uc2dc\ub3c4\ud574\ub3c4 \uacc4\uc18d \uc2e4\ud328\ud558\uba74 \ud638\uc2a4\ud2b8\uc5d0\uc11c Sunshine\uc744 \uc7ac\uc2dc\uc791\ud558\uc138\uc694 \u2014 \uc624\ub798\ub41c \ud398\uc5b4\ub9c1 \uc2dc\ub3c4\uac00 \uc0c8 \uc2dc\ub3c4\ub97c \ucc28\ub2e8\ud560 \uc218 \uc788\uc2b5\ub2c8\ub2e4.",
+            TimedOut: "\ud638\uc2a4\ud2b8\uc5d0\uc11c PIN\uc744 \uc785\ub825\ud558\uae30 \uc804\uc5d0 \ud398\uc5b4\ub9c1 \uc2dc\uac04\uc774 \ucd08\uacfc\ub418\uc5c8\uc2b5\ub2c8\ub2e4.",
+            AlreadyPaired: "\uc774 \ud638\uc2a4\ud2b8\ub294 \uc774\ubbf8 \ud398\uc5b4\ub9c1\ub418\uc5b4 \uc788\uc2b5\ub2c8\ub2e4!",
+            PairingInProgress: "\uc774 \ud638\uc2a4\ud2b8\uc5d0 \ub300\ud55c \ub2e4\ub978 \ud398\uc5b4\ub9c1 \uc2dc\ub3c4\uac00 \uc774\ubbf8 \uc9c4\ud589 \uc911\uc785\ub2c8\ub2e4. \uc644\ub8cc\ub420 \ub54c\uae4c\uc9c0 \uae30\ub2e4\ub9ac\uac70\ub098 \uba3c\uc800 \ucde8\uc18c\ud558\uc138\uc694.",
+            Cancelled: "\ud398\uc5b4\ub9c1\uc774 \ucde8\uc18c\ub418\uc5c8\uc2b5\ub2c8\ub2e4.",
+            HostUnreachable: "\ud638\uc2a4\ud2b8\uc5d0 \uc5f0\uacb0\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4. Sunshine\uc774 \uc2e4\ud589 \uc911\uc778\uac00\uc694?",
+            Internal: "\ud398\uc5b4\ub9c1\uc774 \uc608\uae30\uce58 \uc54a\uac8c \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4.",
+        },
         overwriteMismatch: (currentId: number, incomingId: number) => `호스트 ${currentId}를 ${incomingId}의 데이터로 덮어쓰려 시도했습니다.`,
         details: (host: any) =>
             `웹 ID: ${host.host_id}\n` +

--- a/web/locales/pt-BR.ts
+++ b/web/locales/pt-BR.ts
@@ -145,6 +145,17 @@ export const ptBR: Translations = {
         wakeUpSent: "Pacote Wake-on-LAN enviado. Pode levar um momento para o PC ligar.",
         alreadyPaired: "Este host já está pareado!",
         pairPrompt: (name: string, pin: string) => `Pareie o host ${name} com este PIN:\nPIN: ${pin}`,
+        pairCountdown: (secs: number) => `Digite o PIN no host em at\u00e9 ${Math.floor(secs / 60)}:${("0" + (secs % 60)).slice(-2)}`,
+        pairCancel: "Cancelar pareamento",
+        pairFailReason: {
+            PinIncorrect: "O PIN n\u00e3o corresponde. Se continuar falhando ap\u00f3s novas tentativas, reinicie o Sunshine no host \u2014 uma tentativa de pareamento obsoleta pode bloquear as novas.",
+            TimedOut: "O pareamento expirou antes de o PIN ser digitado no host.",
+            AlreadyPaired: "Este host j\u00e1 est\u00e1 pareado!",
+            PairingInProgress: "Outra tentativa de pareamento para este host j\u00e1 est\u00e1 em andamento. Aguarde a conclus\u00e3o ou cancele-a primeiro.",
+            Cancelled: "Pareamento cancelado.",
+            HostUnreachable: "N\u00e3o foi poss\u00edvel alcan\u00e7ar o host. O Sunshine est\u00e1 em execu\u00e7\u00e3o?",
+            Internal: "O pareamento falhou inesperadamente.",
+        },
         overwriteMismatch: (currentId: number, incomingId: number) => `tentativa de sobrescrever o host ${currentId} com dados do host ${incomingId}`,
         details: (host: any) =>
             `ID Web: ${host.host_id}\n` +

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -145,6 +145,17 @@ export const zhCN: Translations = {
         wakeUpSent: "已发送唤醒包。你的电脑可能需要一点时间才能启动。",
         alreadyPaired: "该主机已经配对！",
         pairPrompt: (name: string, pin: string) => `请在主机 ${name} 上输入以下 PIN 完成配对：\nPIN: ${pin}`,
+        pairCountdown: (secs: number) => `\u8bf7\u5728 ${Math.floor(secs / 60)}:${("0" + (secs % 60)).slice(-2)} \u5185\u5728\u4e3b\u673a\u4e0a\u8f93\u5165 PIN`,
+        pairCancel: "\u53d6\u6d88\u914d\u5bf9",
+        pairFailReason: {
+            PinIncorrect: "PIN \u4e0d\u5339\u914d\u3002\u5982\u679c\u91cd\u8bd5\u540e\u4ecd\u7136\u5931\u8d25\uff0c\u8bf7\u5728\u4e3b\u673a\u4e0a\u91cd\u542f Sunshine \u2014\u2014 \u6b8b\u7559\u7684\u914d\u5bf9\u4f1a\u8bdd\u53ef\u80fd\u4f1a\u963b\u585e\u65b0\u7684\u914d\u5bf9\u3002",
+            TimedOut: "\u5728\u4e3b\u673a\u4e0a\u8f93\u5165 PIN \u4e4b\u524d\uff0c\u914d\u5bf9\u5df2\u8d85\u65f6\u3002",
+            AlreadyPaired: "\u8be5\u4e3b\u673a\u5df2\u914d\u5bf9\uff01",
+            PairingInProgress: "\u8be5\u4e3b\u673a\u5df2\u6709\u53e6\u4e00\u4e2a\u914d\u5bf9\u8bf7\u6c42\u6b63\u5728\u8fdb\u884c\u3002\u8bf7\u7b49\u5f85\u5176\u5b8c\u6210\u6216\u5148\u53d6\u6d88\u5b83\u3002",
+            Cancelled: "\u914d\u5bf9\u5df2\u53d6\u6d88\u3002",
+            HostUnreachable: "\u65e0\u6cd5\u8fde\u63a5\u5230\u4e3b\u673a\u3002Sunshine \u662f\u5426\u6b63\u5728\u8fd0\u884c\uff1f",
+            Internal: "\u914d\u5bf9\u610f\u5916\u5931\u8d25\u3002",
+        },
         overwriteMismatch: (currentId: number, incomingId: number) => `尝试用主机 ${incomingId} 的数据覆盖主机 ${currentId}`,
         details: (host: any) =>
             `Web Id: ${host.host_id}\n` +


### PR DESCRIPTION
## Motivation

Pairing failures currently surface as a bare `PairError` with the real cause discarded in a server log line. Users can't tell a wrong PIN from an expired window from a concurrent-attempt collision — #143, #26, and #19 all look like people hitting this wall blind.

While diagnosing a live setup (Sunshine 2025.924 on Linux) I also found that a second pair attempt while one is pending permanently breaks pairing until Sunshine restarts: Sunshine keys pending pair sessions by client `uniqueid` and uses `emplace`, which never refreshes an existing entry, so a stale/raced PIN leaves the session mid-phase and every later attempt fails with `Out of order call to getservercert`. (Filing that upstream at LizardByte separately, but the client can avoid triggering it.)

## Changes

**Protocol** (`common/src/api_bindings.rs`, backwards compatible — legacy `PairError` variants kept):
- `PostPairResponse1::Pin` now carries `expires_in_secs` so the client can show the real pairing window
- `PostPairResponse1`/`PostPairResponse2` gain `PairFailed { reason, detail }` with a new `PairFailReason` enum: `PinIncorrect | TimedOut | AlreadyPaired | PairingInProgress | Cancelled | HostUnreachable | Internal`

**Server:**
- pairing failures are mapped onto `PairFailReason` + detail instead of being discarded
- per-host in-flight guard: a duplicate `POST /pair` is rejected with `PairingInProgress` in stage 1, before a PIN is even issued (protects Sunshine's fragile pending-session state, see above)
- new `POST /pair/cancel { host_id }` aborts an in-flight attempt (best-effort `/unpair` cleanup) so a lost modal doesn't lock the host for the whole window
- the pairing window is now an explicit server-owned 300s timeout (`Host::PAIR_TIMEOUT_SECS`) with `TimedOut` reported when it lapses

**Web client:**
- new `PairModal`: PIN + live countdown + Cancel button
- localized, actionable failure messages for every reason in all 5 locales (the `PinIncorrect` message includes the restart-Sunshine hint for the stale-session case)

## Testing

- `cargo test` — new unit tests for the error→reason mapping
- Live end-to-end against Sunshine 2025.924:
  - happy path → `Paired`
  - wrong PIN → `PairFailed { reason: PinIncorrect, detail: "...pin was incorrect" }`
  - duplicate attempt → immediate stage-1 `PairFailed { reason: PairingInProgress }`
  - cancel → `POST /pair/cancel` 200, stream ends with `Cancelled`, repeat cancel 404
  - `tsc` clean, clippy clean