### PR TITLE
Fix: honor moonlight.pair_device_name config (was hardcoded "roth")

### DIFF
--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -378,6 +378,8 @@ impl Host {
             return Err(AppError::HostPaired);
         }
 
+        let device_name = app.config.moonlight.pair_device_name.clone();
+
         let modify = self
             .use_client(&app, user, async |this, host| {
                 let (client_identifier, client_secret) = OpenSSLCryptoBackend
@@ -390,7 +392,7 @@ impl Host {
                 host.pair(
                     &client_identifier,
                     &client_secret,
-                    "roth".to_string(),
+                    device_name,
                     pin,
                     OpenSSLCryptoBackend,
                 )


### PR DESCRIPTION
The `moonlight.pair_device_name` config option existed but was silently ignored — `Host::pair` always sent the literal `"roth"` as the `devicename` in the pairing request, regardless of config. This wires the config value through.

Note: Sunshine's paired-clients UI mostly shows the name entered on its own PIN page, so the visible effect there is limited — but the configured value is now what actually goes over the wire, which matters for hosts/tools that do read `devicename`.

Verified with `cargo check` and `cargo test` (all passing).