### PR TITLE
Fix in-band VideoDecoder level hints (silent software-decode above ~720p)

### DIFF
--- a/web/stream/video/codec_level.ts
+++ b/web/stream/video/codec_level.ts
@@ -1,0 +1,127 @@
+import { VideoCodecSupport } from "../video.js"
+
+/// Computes codec strings whose level matches the actual stream dimensions
+/// and frame rate.
+///
+/// The level in the codec string is a promise to the decoder about the
+/// heaviest bitstream it will see. If the hint promises less than the SPS
+/// inside the stream asks for (e.g. a level 3.0 hint for a 1440p120 stream),
+/// Chrome can silently fall back to software decoding even though the
+/// hardware decoder would have been fine. See
+/// https://github.com/MrCreativ3001/moonlight-web-stream/issues/136
+
+// H.264 (ITU-T H.264 Table A-1): level -> [level_idc, MaxFS in MBs, MaxMBPS in MB/s]
+const H264_LEVELS: Array<[number, number, number]> = [
+    [0x1E, 1620, 40500],      // 3.0
+    [0x1F, 3600, 108000],     // 3.1
+    [0x20, 5120, 216000],     // 3.2
+    [0x28, 8192, 245760],     // 4.0
+    [0x2A, 8704, 522240],     // 4.2
+    [0x32, 22080, 589824],    // 5.0
+    [0x33, 36864, 983040],    // 5.1
+    [0x34, 36864, 2073600],   // 5.2
+    [0x3C, 139264, 4177920],  // 6.0
+    [0x3D, 139264, 8355840],  // 6.1
+    [0x3E, 139264, 16711680], // 6.2
+]
+
+// H.265 (ITU-T H.265 Table A.8, main tier): level -> [level as used in the
+// codec string (30 * level number), MaxLumaPs, MaxLumaSr]
+const H265_LEVELS: Array<[number, number, number]> = [
+    [93, 983040, 33177600],       // 3.1
+    [120, 2228224, 66846720],     // 4.0
+    [123, 2228224, 133693440],    // 4.1
+    [150, 8912896, 267386880],    // 5.0
+    [153, 8912896, 534773760],    // 5.1
+    [156, 8912896, 1069547520],   // 5.2
+    [180, 35651584, 1069547520],  // 6.0
+    [183, 35651584, 2139095040],  // 6.1
+    [186, 35651584, 4278190080],  // 6.2
+]
+
+// AV1 (spec Annex A.3): seq_level_idx -> [idx, MaxPicSize in samples, MaxDisplayRate in samples/s]
+const AV1_LEVELS: Array<[number, number, number]> = [
+    [4, 1704960, 39938048],      // 3.0
+    [5, 2359296, 116444160],     // 3.1
+    [8, 2359296, 141557760],     // 4.0 (MaxDisplayRate of 4.1 tier used conservatively below via ordering)
+    [9, 2359296, 283115520],     // 4.1
+    [12, 8912896, 534773760],    // 5.0
+    [13, 8912896, 1069547520],   // 5.1
+    [16, 35651584, 2139095040],  // 6.0
+    [17, 35651584, 4278190080],  // 6.1
+]
+
+function pickLevel(
+    levels: Array<[number, number, number]>,
+    frameSize: number,
+    sampleRate: number,
+): number {
+    for (const [id, maxSize, maxRate] of levels) {
+        if (frameSize <= maxSize && sampleRate <= maxRate) {
+            return id
+        }
+    }
+    // Heavier than the largest level we know: promise the largest. The
+    // decoder will still reject the stream if it truly can't handle it.
+    return levels[levels.length - 1][0]
+}
+
+export function h264LevelIdc(width: number, height: number, fps: number): number {
+    const macroblocks = Math.ceil(width / 16) * Math.ceil(height / 16)
+    return pickLevel(H264_LEVELS, macroblocks, macroblocks * fps)
+}
+
+export function h265Level(width: number, height: number, fps: number): number {
+    const lumaSamples = width * height
+    return pickLevel(H265_LEVELS, lumaSamples, lumaSamples * fps)
+}
+
+export function av1LevelIdx(width: number, height: number, fps: number): number {
+    const samples = width * height
+    return pickLevel(AV1_LEVELS, samples, samples * fps)
+}
+
+function toHex(value: number): string {
+    return ("0" + value.toString(16).toUpperCase()).slice(-2)
+}
+
+function pad2(value: number): string {
+    return ("0" + value).slice(-2)
+}
+
+/// In-band codec strings (avc3/hev1: parameter sets travel in the
+/// bitstream) with the level part computed from the actual stream setup.
+/// Profile bytes stay identical to the previous hardcoded strings; only the
+/// level is dynamic.
+export function videoDecoderCodecInBand(
+    codec: keyof VideoCodecSupport,
+    width: number,
+    height: number,
+    fps: number,
+): string | null {
+    switch (codec) {
+        case "H264":
+            return `avc3.42E0${toHex(h264LevelIdc(width, height, fps))}`
+        case "H264_HIGH8_444":
+            return `avc3.6400${toHex(h264LevelIdc(width, height, fps))}`
+        case "H265":
+            return `hev1.1.6.L${h265Level(width, height, fps)}.B0`
+        case "H265_MAIN10":
+            return `hev1.2.4.L${h265Level(width, height, fps)}.90`
+        case "H265_REXT8_444":
+            return `hev1.6.6.L${h265Level(width, height, fps)}.90`
+        case "H265_REXT10_444":
+            return `hev1.6.10.L${h265Level(width, height, fps)}.90`
+        case "AV1_MAIN8":
+            return `av01.0.${pad2(av1LevelIdx(width, height, fps))}M.08`
+        case "AV1_MAIN10":
+            return `av01.0.${pad2(av1LevelIdx(width, height, fps))}M.10`
+        case "AV1_HIGH8_444":
+            return `av01.0.${pad2(av1LevelIdx(width, height, fps))}M.08`
+        case "AV1_HIGH10_444":
+            return `av01.0.${pad2(av1LevelIdx(width, height, fps))}M.10`
+        default:
+            // Unknown codec: let the caller fall back to its static table
+            return null
+    }
+}

--- a/web/stream/video/video_decoder_pipe.ts
+++ b/web/stream/video/video_decoder_pipe.ts
@@ -4,6 +4,7 @@ import { Logger } from "../log.js";
 import { Pipe, PipeInfo } from "../pipeline/index.js";
 import { addPipePassthrough } from "../pipeline/pipes.js";
 import { emptyVideoCodecs, maybeVideoCodecs, VideoCodecSupport } from "../video.js";
+import { videoDecoderCodecInBand } from "./codec_level.js";
 import { CodecStreamTranslator, H264StreamVideoTranslator, H265StreamVideoTranslator, VIDEO_DECODER_CODECS_OUT_OF_BAND } from "./annex_b_translator.js";
 import { DataVideoRenderer, FrameVideoRenderer, VideoDecodeUnit, VideoRendererSetup } from "./index.js";
 
@@ -135,7 +136,8 @@ export class VideoDecoderPipe implements DataVideoRenderer {
     async setup(setup: VideoRendererSetup): Promise<void> {
         this.fps = setup.fps
 
-        const codec = VIDEO_DECODER_CODECS_IN_BAND[setup.codec]
+        const codec = videoDecoderCodecInBand(setup.codec, setup.width, setup.height, setup.fps)
+            ?? VIDEO_DECODER_CODECS_IN_BAND[setup.codec]
         await this.trySetConfig(codec)
 
         if (!this.config) {


### PR DESCRIPTION
Part of the improvements discussed in #136 (thanks @royka1 for the pointers).

## Problem

`VIDEO_DECODER_CODECS_IN_BAND` hardcodes the level in every codec string: H.264 `avc3.42E01E` (level 3.0 ≈ 720p30), HEVC `hev1.1.6.L93.B0` (3.1), AV1 `av01.0.04M.08`. The level is a promise to the decoder about the heaviest bitstream it will see. For any stream heavier than the hint (i.e. almost every real stream — 1080p60 needs H.264 level 4.2, 1440p120 needs 5.2), the in-band SPS asks for more than the config promised, and Chrome can silently pick a software decoder instead of the hardware one. This is the decode-latency trap described in #136 item 1.

## Change

New `codec_level.ts` computes the level part from the negotiated width/height/fps using the spec tables (H.264 Table A-1 MaxFS/MaxMBPS, H.265 Table A.8 MaxLumaPs/MaxLumaSr, AV1 Annex A.3), and `VideoDecoderPipe.setup` uses it for the in-band config. Profile/constraint bytes are exactly as before — only the level is dynamic. Unknown codecs fall back to the existing static table.

The out-of-band fallback path already derives exact `avc1.PPCCLL` strings from the real SPS bytes and is untouched.

Sample outputs (verified against the spec tables):
- H264 1080p60 → `avc3.42E02A` (4.2), 1440p120 → `avc3.42E034` (5.2), 4K120 → `avc3.42E03C` (6.0)
- H265 1080p60 → `hev1.1.6.L123.B0` (4.1), 1440p120 → `hev1.1.6.L153.B0` (5.1)
- AV1 1440p120 → `av01.0.12M.08` (5.0)

## Scope notes

Of the other #136 items: AVCC out-of-band description building and a Keyboard Lock integration already exist in this codebase, so this PR only addresses the level-hint mismatch. I deliberately left out the SPS `max_num_reorder_frames` rewrite: NVENC under Sunshine already emits zero-reorder VUI, so its benefit here is unproven — happy to follow up if measurements say otherwise.

`tsc` clean; level functions spot-checked via node against hand-computed table values.