### PR TITLE
Fix #98: streamer keeps streaming after the page is closed (WebRTC transport)

### DIFF
--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -355,6 +355,15 @@ pub async fn start_host(
                 _ => {}
             }
         }
+
+        // The websocket dropped (tab closed, navigation, network loss). It is
+        // the client's liveness signal: with WebRTC transport no media flows
+        // through it, so without this the streamer would keep the moonlight
+        // session with the host running and stream to a dead peer until the
+        // peer connection happens to notice (issue #98). Stop the streamer;
+        // the ipc task above then closes the session and reaps the child.
+        info!("[Stream]: client websocket closed, stopping streamer");
+        ipc_sender.send(ServerIpcMessage::Stop).await;
     });
 
     Ok(response)


### PR DESCRIPTION
Fixes #98.

## Root cause

In `start_host` (src/api/stream.rs), the task that forwards websocket messages into the streamer IPC just ends when the websocket closes — nothing tells the streamer. The only stop trigger on this path was a *failed outbound websocket send* (in the ipc→ws task). With **WebSocket transport** media flows through the socket, so the next send fails and the streamer is stopped promptly — which is why this bug looks transport-dependent. With **WebRTC transport**, after signaling completes the streamer rarely (or never) writes to the websocket, so closing the tab leaves the streamer running: the moonlight session with the host stays active and RTP keeps flowing to a dead peer, exactly the symptom reported (only restarting Sunshine or the container stops the traffic; webrtc-rs does not reliably reach `Disconnected` on silent peer loss).

## Fix

Treat the signaling websocket as the client's liveness signal: when the ws receive loop ends, send `ServerIpcMessage::Stop` to the streamer. The streamer already handles `Stop` with a graceful shutdown (ends the moonlight session), and the existing ipc-side cleanup closes the session and reaps the child after its grace period.

## Verification

Live against Sunshine 2025.924: opened `/api/host/stream`, sent `Init`, let the streamer launch and negotiate, then destroyed the TCP socket abruptly (no close frame — simulating a killed tab). Server logged the new stop line immediately and the streamer process exited ~10 s later via the normal cleanup path. Before the patch the streamer stayed alive indefinitely in this scenario.