### PR TITLE
Fix #148: WEBRTC_PORT_RANGE baked into the Docker image overrides config.json

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,6 @@ RUN tar -xvzf /tmp/app.tar.gz --strip-components=1 -C ${MOONLIGHT_WEB_PATH}/ && 
 VOLUME ${MOONLIGHT_WEB_PATH}/server
 
 # Expose the port (adjust if you changed it)
-ENV WEBRTC_PORT_RANGE=40000:40100
 EXPOSE 8080 40000-40100/udp
 
 # Create an entrypoint

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,9 +3,15 @@
 
 Run with
 ```sh
-docker run -d -p 8080:8080 -p 40000-40100:40000-40100/udp -e WEBRTC_NAT_1TO1_HOST=YOUR_LAN_IP mrcreativ3001/moonlight-web-stream:latest
+docker run -d -p 8080:8080 -p 40000-40100:40000-40100/udp -e WEBRTC_NAT_1TO1_HOST=YOUR_LAN_IP -e WEBRTC_PORT_RANGE=40000:40100 mrcreativ3001/moonlight-web-stream:latest
 ```
 and replace `YOUR_LAN_IP` with the device ip address of the local network.
+
+`WEBRTC_PORT_RANGE` must match the udp port mapping. Environment variables
+override `server/config.json`, so if you prefer configuring
+`webrtc.port_range` in the config file (e.g. different ranges for multiple
+instances), don't set the environment variable — it is no longer baked into
+the image.
 
 # Running with a TURN server
 

--- a/docker/docker-compose.with-turn.yaml
+++ b/docker/docker-compose.with-turn.yaml
@@ -12,6 +12,10 @@ services:
       - "40000-40100:40000-40100/udp"
     environment:
       - WEBRTC_NAT_1TO1_HOST=${LAN_ADDRESS}
+      # Must match the udp port mapping above. Remove this line if you set
+      # webrtc.port_range in server/config.json instead (env vars override
+      # the config file).
+      - WEBRTC_PORT_RANGE=40000:40100
       - WEBRTC_ICE_SERVER_0_URL=turn:127.0.0.1:3478?transport=udp # localhost, because we're hosting the turn
       - WEBRTC_ICE_SERVER_0_USERNAME=${TURN_USERNAME}
       - WEBRTC_ICE_SERVER_0_CREDENTIAL=${TURN_CREDENTIAL}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
       - "40000-40100:40000-40100/udp"
     environment:
       - WEBRTC_NAT_1TO1_HOST=127.0.0.1 # Set this to your LAN ip or public ip
+      # Must match the udp port mapping above. Remove this line if you set
+      # webrtc.port_range in server/config.json instead (env vars override
+      # the config file).
+      - WEBRTC_PORT_RANGE=40000:40100
     volumes:
       - moonlight-server:/moonlight-web/server
 


### PR DESCRIPTION
Fixes #148.

`docker/Dockerfile` bakes `ENV WEBRTC_PORT_RANGE=40000:40100` into the image. Since CLI env vars override `server/config.json`, every container silently ignores a user-configured `webrtc.port_range` — the exact multi-instance failure described in #148 (secondary instances with different ranges keep binding 40000–40100 inside the container, so the mapped ports never see traffic and ICE fails).

Changes:
- remove the `ENV` from the Dockerfile — the image no longer forces a range
- set `WEBRTC_PORT_RANGE=40000:40100` in both compose files instead, next to the matching port mapping, with a comment explaining it must match and can be removed in favor of `config.json`
- `docker run` example in the README now passes the env var explicitly, and the README documents the env-over-config precedence

Behavior is unchanged for anyone using the provided compose files or README command; users who configure `webrtc.port_range` per instance now actually get their configured range.