### PR TITLE
Add option to hide the sidebar button during streaming (#155)

### DIFF
--- a/web/component/settings_menu.ts
+++ b/web/component/settings_menu.ts
@@ -8,6 +8,7 @@ import { SidebarEdge } from "./sidebar/index.js";
 
 export type Settings = {
     sidebarEdge: SidebarEdge,
+    hideSidebarButton: boolean,
     bitrate: number
     videoFrameQueueSize: number
     videoSize: "720p" | "1080p" | "1440p" | "4k" | "native" | "custom"
@@ -147,6 +148,7 @@ export class StreamSettingsComponent implements Component {
 
     private sidebarHeader: HTMLHeadingElement = document.createElement("h3")
     private sidebarEdge: SelectComponent
+    private hideSidebarButton: InputComponent
 
     private streamHeader: HTMLHeadingElement = document.createElement("h3")
     private bitrate: InputComponent
@@ -220,6 +222,12 @@ export class StreamSettingsComponent implements Component {
         })
         this.sidebarEdge.addChangeListener(this.onSettingsChange.bind(this))
         this.sidebarEdge.mount(this.divElement)
+
+        this.hideSidebarButton = new InputComponent("hideSidebarButton", "checkbox", i.hideSidebarButton, {
+            checked: settings?.hideSidebarButton ?? defaultSettings_.hideSidebarButton
+        })
+        this.hideSidebarButton.addChangeListener(this.onSettingsChange.bind(this))
+        this.hideSidebarButton.mount(this.divElement)
 
         // Video
         this.streamHeader.innerText = i.video
@@ -554,6 +562,7 @@ export class StreamSettingsComponent implements Component {
         const settings = globalDefaultSettings()
 
         settings.sidebarEdge = this.sidebarEdge.getValue() as any
+        settings.hideSidebarButton = this.hideSidebarButton.isChecked()
         settings.bitrate = parseInt(this.bitrate.getValue())
         settings.fps = parseInt(this.fps.getValue())
         settings.videoSize = this.videoSize.getValue() as any

--- a/web/default_settings.ts
+++ b/web/default_settings.ts
@@ -7,6 +7,7 @@ const trueDefaultSettings: Settings =
 {
     // possible values: "left", "right", "up", "down"
     "sidebarEdge": "left",
+    "hideSidebarButton": false,
     "bitrate": 10000,
     "fps": 60,
     "videoFrameQueueSize": 3,

--- a/web/locales/en.ts
+++ b/web/locales/en.ts
@@ -39,6 +39,7 @@ export const en = {
     settings: {
         sidebar: "Sidebar",
         sidebarEdge: "Sidebar Edge",
+        hideSidebarButton: "Hide Sidebar Button (reveal on hover)",
         left: "Left",
         right: "Right",
         up: "Up",

--- a/web/locales/fr-FR.ts
+++ b/web/locales/fr-FR.ts
@@ -41,6 +41,7 @@ export const frFr: Translations = {
     settings: {
         sidebar: "Barre latérale",
         sidebarEdge: "Bord de la barre latérale",
+        hideSidebarButton: "Masquer le bouton de la barre latérale (visible au survol)",
         left: "Gauche",
         right: "Droite",
         up: "Haut",

--- a/web/locales/ko-KR.ts
+++ b/web/locales/ko-KR.ts
@@ -41,6 +41,7 @@ export const koKR: Translations = {
     settings: {
         sidebar: "사이드바",
         sidebarEdge: "사이드바 위치",
+        hideSidebarButton: "사이드바 버튼 숨기기 (마우스를 올리면 표시)",
         left: "왼쪽",
         right: "오른쪽",
         up: "위",

--- a/web/locales/pt-BR.ts
+++ b/web/locales/pt-BR.ts
@@ -41,6 +41,7 @@ export const ptBR: Translations = {
     settings: {
         sidebar: "Barra Lateral",
         sidebarEdge: "Posição da Barra Lateral",
+        hideSidebarButton: "Ocultar botão da barra lateral (aparece ao passar o mouse)",
         left: "Esquerda",
         right: "Direita",
         up: "Cima",

--- a/web/locales/zh-CN.ts
+++ b/web/locales/zh-CN.ts
@@ -41,6 +41,7 @@ export const zhCN: Translations = {
     settings: {
         sidebar: "侧边栏",
         sidebarEdge: "侧边栏位置",
+        hideSidebarButton: "隐藏侧边栏按钮（悬停时显示）",
         left: "左",
         right: "右",
         up: "上",

--- a/web/stream.ts
+++ b/web/stream.ts
@@ -250,6 +250,10 @@ class ViewerApp implements Component {
             edge: settings.sidebarEdge,
         })
 
+        // Optionally keep the sidebar toggle invisible until hovered/focused
+        document.getElementById("sidebar-button")
+            ?.classList.toggle("sidebar-button-unobtrusive", settings.hideSidebarButton)
+
         // Add app info listener
         this.stream.addInfoListener(this.onInfo.bind(this))
 

--- a/web/styles/moonlight.css
+++ b/web/styles/moonlight.css
@@ -449,6 +449,18 @@ input[type=number] {
     transition: all 0.3s linear;
 }
 
+/** "Hide sidebar button" stream setting: invisible until hovered or focused,
+    so it never overlays the game but stays reachable in the same spot. */
+.sidebar-button.sidebar-button-unobtrusive {
+    opacity: 0;
+    transition: opacity 0.2s linear;
+}
+.sidebar-button.sidebar-button-unobtrusive:hover,
+.sidebar-button.sidebar-button-unobtrusive:focus-visible,
+.sidebar-show .sidebar-button.sidebar-button-unobtrusive {
+    opacity: 1;
+}
+
 .sidebar-edge-left .sidebar-button-image {
     rotate: 180deg;
 }


### PR DESCRIPTION
Closes #155.

Adds a **Hide Sidebar Button (reveal on hover)** checkbox to the sidebar section of the stream settings (same pattern and apply-point as `sidebarEdge`). When enabled, the sidebar arrow is fully transparent during the stream so it never overlays the game — it keeps its position and hit area, and fades back in on hover, keyboard focus, or while the sidebar is open, so it can't be lost.

- `hideSidebarButton` setting: type + default (`false`) + checkbox + persistence, following the existing settings plumbing
- CSS opacity toggle on `#sidebar-button` (`.sidebar-button-unobtrusive`)
- labels added to all five locales

`tsc` clean.