### PR TITLE
Fix EncodedVideoChunk TypeError on timestamp wrap/reset (negative duration)

### DIFF
--- a/web/stream/video/depackitize_pipe.ts
+++ b/web/stream/video/depackitize_pipe.ts
@@ -44,7 +44,10 @@ export class DepacketizeVideoPipe implements DataPipe {
         const frameType = this.buffer.getU8()
         const timestamp = this.buffer.getU32()
 
-        const duration = timestamp - this.lastTimestampMicroseconds
+        // The u32 timestamp wraps (~71 min of microseconds) and resets on
+        // host reconnect; a negative delta makes EncodedVideoChunk throw
+        // (duration must fit unsigned long long). Clamp to zero in that case.
+        const duration = Math.max(0, timestamp - this.lastTimestampMicroseconds)
         this.base.submitDecodeUnit({
             type: frameType == 0 ? "delta" : "key",
             data: array.slice(5).buffer,


### PR DESCRIPTION
Observed live: mid-stream, every frame began failing with `TypeError: Failed to construct 'EncodedVideoChunk': ... 'duration' ... outside the 'unsigned long long' value range`, killing the WebCodecs decode path.

`DepacketizeVideoPipe` computes each unit's duration as the delta between consecutive u32 microsecond timestamps. That value wraps about every 71 minutes and resets when the host session restarts, so the delta can go negative — and `EncodedVideoChunkInit.duration` must be a non-negative integer. Clamped to zero on negative deltas.