### PR TITLE
Add AV1 WebCodecs translation and stalled-stream recovery

### DIFF
--- a/web/stream/transport/web_socket.ts
+++ b/web/stream/transport/web_socket.ts
@@ -119,11 +119,7 @@ export class WebSocketTransport implements Transport {
                 this.controlStream.onRawPacket(view.subarray(1))
             } else if (channel == WebSocketChannel.VIDEO) {
                 this.videoPipeline?.submitPacket(view.subarray(1))
-                if (this.videoPipeline && "pollRequestIdr" in this.videoPipeline && typeof this.videoPipeline.pollRequestIdr == "function" && this.videoPipeline.pollRequestIdr()) {
-                    this.logger?.debug("requesting idr")
-
-                    this.controlStream.sendRaw(new ControlPacket.RequestIdr())
-                }
+                this.requestIdrIfNeeded()
             } else if (channel == WebSocketChannel.AUDIO) {
                 this.audioPipeline?.submitPacket(view.subarray(1))
             }
@@ -161,6 +157,15 @@ export class WebSocketTransport implements Transport {
     }
 
     private videoPipeline: DataPipe | null = null
+    private videoWatchdogInterval: number | null = null
+
+    private requestIdrIfNeeded() {
+        if (this.videoPipeline && "pollRequestIdr" in this.videoPipeline && typeof this.videoPipeline.pollRequestIdr == "function" && this.videoPipeline.pollRequestIdr()) {
+            this.logger?.debug("requesting idr")
+
+            this.controlStream.sendRaw(new ControlPacket.RequestIdr())
+        }
+    }
 
     setVideoPipeline(type: "videotrack", pipeline: (TrackVideoRenderer & VideoRenderer)): Promise<void>
     setVideoPipeline(type: "data", pipeline: (DataPipe & VideoRenderer)): Promise<void>
@@ -170,6 +175,7 @@ export class WebSocketTransport implements Transport {
         }
 
         this.videoPipeline = pipeline as (DataPipe & AudioPlayer)
+        this.videoWatchdogInterval ??= globalObject().setInterval(() => this.requestIdrIfNeeded(), 250)
     }
 
     private audioPipeline: (DataPipe & AudioPlayer) | null = null
@@ -248,6 +254,10 @@ export class WebSocketTransport implements Transport {
 
     private dispatchedClosed: boolean = false
     async close(): Promise<void> {
+        if (this.videoWatchdogInterval != null) {
+            globalObject().clearInterval(this.videoWatchdogInterval)
+            this.videoWatchdogInterval = null
+        }
         this.ws.close()
         if (!this.dispatchedClosed && this.onclose) {
             if (this.wasConnected) {

--- a/web/stream/video/annex_b_translator.ts
+++ b/web/stream/video/annex_b_translator.ts
@@ -53,7 +53,7 @@ export abstract class CodecStreamTranslator {
 
     protected currentFrame = new Uint8Array(1000)
 
-    submitDecodeUnit(unit: VideoDecodeUnit): { configure: VideoDecoderConfig | null, chunk: Uint8Array | null, error: false } | { error: true } {
+    submitDecodeUnit(unit: VideoDecodeUnit): { configure: VideoDecoderConfig | null, chunk: Uint8Array | null, type?: EncodedVideoChunkType, error: false } | { error: true } {
         if (!this.decoderConfig) {
             this.logger?.debug("Failed to retrieve decoderConfig which should already exist for VideoDecoder", { type: "fatal" })
             return { error: true }
@@ -145,6 +145,280 @@ export abstract class CodecStreamTranslator {
             newFrame.set(this.currentFrame);
             this.currentFrame = newFrame;
         }
+    }
+}
+
+type Av1Obu = {
+    type: number
+    header: Uint8Array
+    payload: Uint8Array
+}
+
+const AV1_OBU_SEQUENCE_HEADER = 1
+const AV1_OBU_TEMPORAL_DELIMITER = 2
+const AV1_OBU_TILE_LIST = 8
+const AV1_OBU_PADDING = 15
+
+function readLeb128(data: Uint8Array, offset: number): { value: number, offset: number } | null {
+    let value = 0
+
+    for (let i = 0; i < 8; i++) {
+        if (offset >= data.length) {
+            return null
+        }
+
+        const b = data[offset++]
+        value += (b & 0x7f) * 2 ** (i * 7)
+
+        if (!Number.isSafeInteger(value)) {
+            return null
+        }
+
+        if ((b & 0x80) == 0) {
+            return { value, offset }
+        }
+    }
+
+    return null
+}
+
+function writeLeb128(value: number): Uint8Array {
+    const bytes = []
+
+    do {
+        let b = value % 0x80
+        value = Math.floor(value / 0x80)
+        if (value != 0) {
+            b |= 0x80
+        }
+        bytes.push(b)
+    } while (value != 0)
+
+    return new Uint8Array(bytes)
+}
+
+function av1ObuType(header: number): number {
+    return (header >> 3) & 0x0f
+}
+
+function isValidAv1ObuHeader(header: number): boolean {
+    const forbidden = (header & 0x80) != 0
+    const reserved = (header & 0x01) != 0
+    const type = av1ObuType(header)
+
+    return !forbidden && !reserved && type > 0
+}
+
+function parseAv1LowOverheadObus(data: Uint8Array): Av1Obu[] | null {
+    const obus: Av1Obu[] = []
+    let offset = 0
+
+    while (offset < data.length) {
+        const obuStart = offset
+        const header = data[offset++]
+
+        if (!isValidAv1ObuHeader(header)) {
+            return null
+        }
+
+        const hasExtension = (header & 0x04) != 0
+        const hasSize = (header & 0x02) != 0
+        const headerEnd = offset + (hasExtension ? 1 : 0)
+
+        if (headerEnd > data.length) {
+            return null
+        }
+
+        offset = headerEnd
+
+        if (!hasSize) {
+            obus.push({
+                type: av1ObuType(header),
+                header: data.slice(obuStart, headerEnd),
+                payload: data.slice(offset),
+            })
+            offset = data.length
+            break
+        }
+
+        const size = readLeb128(data, offset)
+        if (!size || size.offset + size.value > data.length) {
+            return null
+        }
+        offset = size.offset
+        obus.push({
+            type: av1ObuType(header),
+            header: data.slice(obuStart, headerEnd),
+            payload: data.slice(offset, offset + size.value),
+        })
+        offset += size.value
+    }
+
+    return obus.length > 0 ? obus : null
+}
+
+function av1ShouldDropObu(obu: Av1Obu): boolean {
+    return obu.type == AV1_OBU_TEMPORAL_DELIMITER ||
+        obu.type == AV1_OBU_TILE_LIST ||
+        obu.type == AV1_OBU_PADDING
+}
+
+function parseAv1AnnexBObus(data: Uint8Array): Av1Obu[] | null {
+    const obus: Av1Obu[] = []
+    let temporalOffset = 0
+
+    while (temporalOffset < data.length) {
+        const temporalUnit = readLeb128(data, temporalOffset)
+        if (!temporalUnit || temporalUnit.value <= 0 || temporalUnit.offset + temporalUnit.value > data.length) {
+            return null
+        }
+
+        let frameOffset = temporalUnit.offset
+        const temporalEnd = temporalUnit.offset + temporalUnit.value
+
+        while (frameOffset < temporalEnd) {
+            const frameUnit = readLeb128(data, frameOffset)
+            if (!frameUnit || frameUnit.value <= 0 || frameUnit.offset + frameUnit.value > temporalEnd) {
+                return null
+            }
+
+            let obuOffset = frameUnit.offset
+            const frameEnd = frameUnit.offset + frameUnit.value
+
+            while (obuOffset < frameEnd) {
+                const obuLength = readLeb128(data, obuOffset)
+                if (!obuLength || obuLength.value <= 0 || obuLength.offset + obuLength.value > frameEnd) {
+                    return null
+                }
+
+                const obuStart = obuLength.offset
+                const header = data[obuStart]
+                if (!isValidAv1ObuHeader(header)) {
+                    return null
+                }
+
+                const hasExtension = (header & 0x04) != 0
+                const headerEnd = obuStart + 1 + (hasExtension ? 1 : 0)
+                if (headerEnd > obuLength.offset + obuLength.value) {
+                    return null
+                }
+
+                obus.push({
+                    type: av1ObuType(header),
+                    header: data.slice(obuStart, headerEnd),
+                    payload: data.slice(headerEnd, obuLength.offset + obuLength.value),
+                })
+
+                obuOffset = obuLength.offset + obuLength.value
+            }
+
+            frameOffset = frameEnd
+        }
+
+        temporalOffset = temporalEnd
+    }
+
+    return obus.length > 0 ? obus : null
+}
+
+function parseAv1SingleObu(data: Uint8Array): Av1Obu[] | null {
+    if (data.length == 0 || !isValidAv1ObuHeader(data[0])) {
+        return null
+    }
+
+    const header = data[0]
+    const hasExtension = (header & 0x04) != 0
+    const headerEnd = 1 + (hasExtension ? 1 : 0)
+    if (headerEnd > data.length) {
+        return null
+    }
+
+    return [{
+        type: av1ObuType(header),
+        header: data.slice(0, headerEnd),
+        payload: data.slice(headerEnd),
+    }]
+}
+
+function serializeAv1LowOverheadObus(obus: Av1Obu[]): Uint8Array {
+    let size = 0
+
+    for (const obu of obus) {
+        size += obu.header.length + writeLeb128(obu.payload.length).length + obu.payload.length
+    }
+
+    const output = new Uint8Array(size)
+    let offset = 0
+
+    for (const obu of obus) {
+        const header = new Uint8Array(obu.header)
+        header[0] |= 0x02
+
+        const payloadSize = writeLeb128(obu.payload.length)
+
+        output.set(header, offset)
+        offset += header.length
+        output.set(payloadSize, offset)
+        offset += payloadSize.length
+        output.set(obu.payload, offset)
+        offset += obu.payload.length
+    }
+
+    return output
+}
+
+export class Av1StreamVideoTranslator extends CodecStreamTranslator {
+    private seenSequenceHeader = false
+    private configured = false
+
+    submitDecodeUnit(unit: VideoDecodeUnit): { configure: VideoDecoderConfig | null, chunk: Uint8Array | null, type?: EncodedVideoChunkType, error: false } | { error: true } {
+        const data = new Uint8Array(unit.data)
+        const lowOverheadObus = parseAv1LowOverheadObus(data)
+        const annexBObus = lowOverheadObus ? null : parseAv1AnnexBObus(data)
+        const singleObu = lowOverheadObus || annexBObus ? null : parseAv1SingleObu(data)
+        const obus = lowOverheadObus ?? annexBObus ?? singleObu
+
+        if (!obus) {
+            this.logger?.debug(`Failed to parse AV1 decode unit (${data.length} bytes)`, { type: "fatal" })
+            return { error: true }
+        }
+
+        const hasSequenceHeader = obus.some(obu => obu.type == AV1_OBU_SEQUENCE_HEADER)
+
+        if (hasSequenceHeader) {
+            this.seenSequenceHeader = true
+        }
+
+        if (!this.seenSequenceHeader && unit.type != "key") {
+            return { configure: null, chunk: null, error: false }
+        }
+
+        const frameObus = obus.filter(obu => !av1ShouldDropObu(obu))
+        if (frameObus.length == 0) {
+            return { configure: null, chunk: null, error: false }
+        }
+
+        const chunk = serializeAv1LowOverheadObus(frameObus)
+
+        const configure = this.configured ? null : this.decoderConfig
+        this.configured = true
+
+        return {
+            configure,
+            chunk,
+            type: unit.type,
+            error: false,
+        }
+    }
+
+    protected startProcessChunk(_unit: VideoDecodeUnit): { shouldProcess: boolean } {
+        return { shouldProcess: false }
+    }
+    protected onChunkUnit(_slice: Uint8Array): { include: boolean } {
+        return { include: false }
+    }
+    protected endChunk(): { reconfigure: boolean } {
+        return { reconfigure: false }
     }
 }
 

--- a/web/stream/video/video_decoder_pipe.ts
+++ b/web/stream/video/video_decoder_pipe.ts
@@ -5,8 +5,14 @@ import { Pipe, PipeInfo } from "../pipeline/index"
 import { addPipePassthrough } from "../pipeline/pipes"
 import { emptyVideoCodecs, } from "../video"
 import { videoDecoderCodecInBand } from "./codec_level"
-import { CodecStreamTranslator, H264StreamVideoTranslator, H265StreamVideoTranslator, VIDEO_DECODER_CODECS_OUT_OF_BAND } from "./annex_b_translator"
+import { Av1StreamVideoTranslator, CodecStreamTranslator, H264StreamVideoTranslator, H265StreamVideoTranslator, VIDEO_DECODER_CODECS_OUT_OF_BAND } from "./annex_b_translator"
 import { DataVideoRenderer, FrameVideoRenderer, VideoDecodeUnit, VideoRendererSetup } from "./index"
+
+const DECODER_QUEUE_STALL_MS = 200
+const DECODER_OUTPUT_STALL_MS = 1500
+const VIDEO_INPUT_STALL_MS = 1500
+const ACTIVE_VIDEO_INPUT_MS = 500
+const IDR_RETRY_INTERVAL_MS = 1000
 
 export const VIDEO_DECODER_CODECS_IN_BAND: Record<keyof VideoFormats, string> = {
     // avc1 = out of band config, avc3 = in band with sps, pps, idr
@@ -118,6 +124,7 @@ export class VideoDecoderPipe implements DataVideoRenderer {
     }
 
     private onOutput(frame: VideoFrame) {
+        this.lastDecoderOutputAt = Date.now()
         this.base.submitFrame(frame)
     }
 
@@ -155,6 +162,11 @@ export class VideoDecoderPipe implements DataVideoRenderer {
         this.width = setup.width
         this.height = setup.height
         this.fps = setup.fps
+        const isAv1 = setup.codec == "av1Main8" || setup.codec == "av1Main10" || setup.codec == "av1High8444" || setup.codec == "av1High10444"
+
+        if (isAv1) {
+            this.translator = new Av1StreamVideoTranslator(this.logger ?? undefined)
+        }
 
         const codec = videoDecoderCodecInBand(setup.codec, setup.width, setup.height, setup.fps)
             ?? VIDEO_DECODER_CODECS_IN_BAND[setup.codec]
@@ -172,9 +184,8 @@ export class VideoDecoderPipe implements DataVideoRenderer {
                 const codec = VIDEO_DECODER_CODECS_OUT_OF_BAND[setup.codec]
                 await this.trySetConfig(codec)
             } else if (setup.codec == "av1Main8" || setup.codec == "av1Main10" || setup.codec == "av1High8444" || setup.codec == "av1High10444") {
-                this.errored = true
-                this.logger?.debug("Av1 stream translator is not implemented currently!", { type: "fatalDescription" })
-                return
+                const codec = VIDEO_DECODER_CODECS_OUT_OF_BAND[setup.codec]
+                await this.trySetConfig(codec)
             } else {
                 this.errored = true
                 this.logger?.debug(`Failed to find stream translator for codec ${setup.codec}`)
@@ -202,6 +213,10 @@ export class VideoDecoderPipe implements DataVideoRenderer {
 
     private decoderSetupFinished = false
     private requestedIdr = false
+    private lastIdrRequestAt = 0
+    private lastVideoInputAt = 0
+    private lastDecodeSubmitAt = 0
+    private lastDecoderOutputAt = Date.now()
     private needsKeyFrame = true
 
     private bufferedUnits: Array<VideoDecodeUnit> = []
@@ -210,6 +225,7 @@ export class VideoDecoderPipe implements DataVideoRenderer {
             console.debug("Cannot submit video decode unit because the stream errored")
             return
         }
+        this.lastVideoInputAt = Date.now()
         if (!this.decoderSetupFinished) {
             this.bufferedUnits.push(unit)
             return
@@ -232,7 +248,7 @@ export class VideoDecoderPipe implements DataVideoRenderer {
                 return
             }
 
-            const { configure, chunk } = value
+            const { configure, chunk, type } = value
 
             if (!chunk) {
                 console.debug("No chunk received!")
@@ -245,16 +261,25 @@ export class VideoDecoderPipe implements DataVideoRenderer {
                 this.decoder.reset()
                 this.decoder.configure(configure)
 
+            }
+
+            const chunkType = type ?? unit.type
+            if (chunkType != "key" && this.needsKeyFrame) {
+                return
+            }
+            this.needsKeyFrame = false
+            if (chunkType == "key") {
                 // This likely is an idr
                 this.requestedIdr = false
             }
 
             const encodedChunk = new EncodedVideoChunk({
-                type: unit.type,
+                type: chunkType,
                 timestamp: unit.timestampMicroseconds,
                 duration: unit.durationMicroseconds,
                 data: chunk,
             })
+            this.lastDecodeSubmitAt = Date.now()
             this.decoder.decode(encodedChunk)
         } else {
             if (unit.type != "key" && this.needsKeyFrame) {
@@ -270,21 +295,24 @@ export class VideoDecoderPipe implements DataVideoRenderer {
                 duration: unit.durationMicroseconds
             })
 
+            this.lastDecodeSubmitAt = Date.now()
             this.decoder.decode(chunk)
         }
     }
 
     private reset() {
-        if (!this.translator) {
-            this.decoder.reset()
-            this.needsKeyFrame = true
+        this.decoder.reset()
+        this.needsKeyFrame = true
+        this.lastDecodeSubmitAt = 0
+        this.lastDecoderOutputAt = Date.now()
 
-            if (this.config) {
-                this.decoder.configure(this.config)
-            } else {
-                this.logger?.debug("Failed to configure VideoDecoder because of missing config", { type: "fatal" })
-            }
-        } else if (this.config) {
+        if (this.config) {
+            this.decoder.configure(this.config)
+        } else {
+            this.logger?.debug("Failed to configure VideoDecoder because of missing config", { type: "fatal" })
+        }
+
+        if (this.translator && this.config) {
             this.translator.setBaseConfig(this.config)
         }
     }
@@ -292,16 +320,35 @@ export class VideoDecoderPipe implements DataVideoRenderer {
     pollRequestIdr(): boolean {
         let requestIdr = false
 
+        const now = Date.now()
         const estimatedQueueDelayMs = this.decoder.decodeQueueSize * 1000 / this.fps
-        if (estimatedQueueDelayMs > 200 && this.decoder.decodeQueueSize > 2) {
-            // We have more than 200ms second backlog in the decoder
-            // -> This decoder is ass, request idr, flush that decoder
+        // We have more than 200ms second backlog in the decoder
+        // -> This decoder is ass, request idr, flush that decoder
+        const queueStalled = estimatedQueueDelayMs > DECODER_QUEUE_STALL_MS && this.decoder.decodeQueueSize > 2
+        const outputStalled = this.lastDecodeSubmitAt > 0 &&
+            now - this.lastDecodeSubmitAt < ACTIVE_VIDEO_INPUT_MS &&
+            now - this.lastDecoderOutputAt > DECODER_OUTPUT_STALL_MS
+        const inputStalled = this.lastVideoInputAt > 0 && now - this.lastVideoInputAt > VIDEO_INPUT_STALL_MS
+        const idrResponseStalled = this.requestedIdr && now - this.lastIdrRequestAt >= IDR_RETRY_INTERVAL_MS
 
-            if (!this.requestedIdr) {
+        if (queueStalled || outputStalled || inputStalled || idrResponseStalled) {
+            if (!this.requestedIdr || now - this.lastIdrRequestAt >= IDR_RETRY_INTERVAL_MS) {
                 requestIdr = true
-                this.reset()
+                this.lastIdrRequestAt = now
+                if (!this.requestedIdr) {
+                    this.reset()
+                }
             }
-            console.debug(`Requesting idr because of decode queue size(${this.decoder.decodeQueueSize}) and estimated delay of the queue: ${estimatedQueueDelayMs}`)
+            if (requestIdr) {
+                const reason = outputStalled
+                    ? `no decoder output for ${now - this.lastDecoderOutputAt}ms while video input is active`
+                    : inputStalled
+                        ? `no video input for ${now - this.lastVideoInputAt}ms`
+                        : idrResponseStalled
+                            ? "the previous idr request did not produce a key frame"
+                            : `decode queue size(${this.decoder.decodeQueueSize}) and estimated delay ${estimatedQueueDelayMs}ms`
+                console.debug(`Requesting idr because of ${reason}`)
+            }
         }
 
         if ("pollRequestIdr" in this.base && typeof this.base.pollRequestIdr == "function") {
@@ -312,6 +359,7 @@ export class VideoDecoderPipe implements DataVideoRenderer {
 
         if (requestIdr) {
             this.requestedIdr = true
+            this.lastIdrRequestAt = now
         }
 
         return requestIdr


### PR DESCRIPTION
## Summary

- add an AV1 stream translator that accepts Sunshine/Moonlight AV1 Annex B, low-overhead, and single-OBU decode units and normalizes them to WebCodecs low-overhead OBU format
- route AV1 through the translator in the WebSocket data video pipeline while leaving the native WebRTC track path unchanged
- fully reset and reconfigure stalled `VideoDecoder` instances, discard delta frames until a key frame arrives, and retry IDR requests until recovery
- poll the WebSocket video pipeline independently so a complete gap in incoming video can also trigger an IDR request

## Problem

A transient packet loss or WebCodecs decoder stall could leave the video permanently frozen even though the stream remained connected. The existing queue-based recovery path did not reset translated decoders, did not retry a lost IDR request, and only ran while video packets were arriving. AV1 data frames could also reach WebCodecs without conversion from Sunshine's stream representation.

## Scope

This changes the WebSocket/data video path. WebRTC streams that use a native `MediaStreamTrack` do not pass through `VideoDecoderPipe` and are unaffected.

## Validation

- `cargo test --workspace --locked` (79 passed)
- `npx tsc --noEmit`
- `npx webpack --mode=production`
- manually validated AV1 playback and recovery with Sunshine `av1_amf`, AMD Radeon RX 9070 XT, Chromium WebCodecs, 3840x2160 at 60 FPS

Webpack reports only the existing asset-size warnings.